### PR TITLE
Closes-Bug: 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Bosh Lite is a lightweight local development environment for BOSH using Warden/G
 
 * Follow instructions at https://github.com/cloudfoundry/bosh-lite/blob/master/README.md#install-bosh-lite
 * Run `vagrant ssh` and then remove `8.8.8.8` from `/etc/resolv.conf` to avoid 5s timeouts
+* If you want to work with BOSH2.0 and want to deploy [bosh-deployment](https://github.com/cloudfoundry/bosh-deployment), then please follow the bosh-lite installation guide as described in https://bosh.io/docs/bosh-lite.
 
 ### Installing Cloud Foundry
 
@@ -72,7 +73,7 @@ cd openssl-1.0.1p
 make
 sudo make install
 # add 2>/dev/null to the bosh <command> calls in ./scripts/generate-bosh-lite-dev-manifest
-
+```
 * If you run into certificate errors from consul like "Unexpected response code: 500 (rpc error: failed to get conn: x509: certificate has expired or is not yet valid)". This means the certificates has expired and it is required to recreate the certificates. Follow the steps below:
   * Generate new certificates using the script cf-release/scripts/generate-consul-certs.
   * Copy the certificates in the relevant section of cf-release/templates/cf-infrastructure-bosh-lite.yml
@@ -82,11 +83,29 @@ sudo make install
     bosh create release && bosh upload release && bosh deploy
     ```
 * Follow instructions at https://docs.cloudfoundry.org/cf-cli/install-go-cli.html to install cf cli
+
+* If you have installed bosh-lite using [bosh-deployment](https://github.com/cloudfoundry/bosh-deployment), then you can deploy cf using the following commands, using [cf-deployment](https://github.com/cloudfoundry/cf-deployment).
+
+```shell
+git clone https://github.com/cloudfoundry/cf-deployment  
+cd cf-deployment  
+bosh2 -e vbox upload-stemcell https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent  
+bosh2 -e vbox update-cloud-config bosh-lite/cloud-config.yml  
+bosh2 -e vbox -d cf deploy cf-deployment.yml -o operations/bosh-lite.yml --vars-store deployment-vars.yml -v system_domain=bosh-lite.com
 ```
+
 * Target, Login, Prepare Cloud Foundry Usage
 ```shell
 cf api --skip-ssl-validation api.bosh-lite.com
-cf login -u admin -p admin
+cf login -u admin -p admin 
+```
+Password will be different in case if you are using using [cf-deployment](https://github.com/cloudfoundry/cf-deployment).
+```shell
+export CF_ADMIN_PASSWORD=$(bosh2 int ./deployment-vars.yml --path /cf_admin_password)  
+cf auth admin $CF_ADMIN_PASSWORD
+```
+Now, sample orgs and spaces can be created to start using it.
+```shell
 cf create-org dev
 cf create-space -o dev broker
 cf target -o dev -s broker
@@ -116,7 +135,7 @@ Useful prerequisites: When working with the broker, install `curl` (`sudo apt-ge
 If you need to change the `settings.yml` configuration you should copy the file and point the broker to your settings file via the environment variable `SETTINGS_PATH`.
 ```shell
 # env vars you may like to set to different than these default values
-# export NODE_ENV=development
+# export NODE_ENV=development ## For bosh2.0, use the environment boshlite2, as the passwords and BOSH IP are different.
 # export SETTINGS_PATH=$(pwd)/config/settings.yml 
 npm run -s start
 ```
@@ -141,7 +160,7 @@ cf service-access # should show all services as enabled, cf marketplace should s
 
 In order for the broker to provision bosh director based services, the releases used in the service manifest templates must be manually uploaded to the targetted bosh director.
 The catalog (`config/settings.yml`) only contains our own [blueprint-service](https://github.com/sap/service-fabrik-blueprint-service) which we are using for internal development, testing and documentation purposes of the Service Fabrik.
-If you want to provision our `blueprint-service` as bosh director based service, follow the steps mentioned in [blueprint-boshrelease](https://github.com/sap/service-fabrik-blueprint-boshrelease) repository
+If you want to provision our `blueprint-service` as bosh director based service, follow the steps mentioned in [blueprint-boshrelease](https://github.com/sap/service-fabrik-blueprint-boshrelease) repository.
 
 ### Run a Service Lifecycle
 
@@ -162,4 +181,4 @@ If you need any support, have any question or have found a bug, please report it
 
 ## LICENSE
 
-This project is licensed under the Apache Software License, v. 2 except as noted otherwise in the [LICENSE](LICENSE) file
+This project is licensed under the Apache Software License, v. 2 except as noted otherwise in the [LICENSE](LICENSE) file.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -324,7 +324,8 @@ defaults: &defaults
   # SERVICES CATALOG - BLUEPRINT SERVICE #
   ########################################
   services:
-  - id: '24731fb8-7b84-4f57-914f-c3d55d793dd4'
+  - &blueprint_service
+    id: '24731fb8-7b84-4f57-914f-c3d55d793dd4'
     name: 'blueprint'
     description: &description 'Blueprint service for internal development, testing, and documentation purposes of the Service Fabrik'
     bindable: true
@@ -346,7 +347,8 @@ defaults: &defaults
     ###########################
     # CONTAINER SERVICE PLANS #
     ###########################
-    - id: '466c5078-df6e-427d-8fb2-c76af50c0f56'
+    - &blueprint_plan1
+      id: '466c5078-df6e-427d-8fb2-c76af50c0f56'
       name: 'v1.0-container'
       free: true
       manager:
@@ -377,7 +379,8 @@ defaults: &defaults
         - 'Container Deployment'
         - '128 MB Memory'
         - '100 MB Disk'
-    - id: '6a252f89-c974-4ef9-a4de-c49f300de39a'
+    - &blueprint_plan2
+      id: '6a252f89-c974-4ef9-a4de-c49f300de39a'
       name: 'v1.0-container-large'
       free: true
       manager:
@@ -411,18 +414,19 @@ defaults: &defaults
     ###########################
     # DEDICATED SERVICE PLANS #
     ###########################
-    - id: 'bc158c9a-7934-401e-94ab-057082a5073f'
+    - &blueprint_plan3
+      id: 'bc158c9a-7934-401e-94ab-057082a5073f'
       name: 'v1.0-dedicated-xsmall'
       free: false
-      manager:
+      manager: &manager_plan3
         name: 'director'
-        settings:
+        settings: &settings_plan3
           prefix: 'blueprint'
           agent: *agent_blueprint
           template: <%= base64_template('blueprint') %>
           releases: &dedicated_releases
           - { name: blueprint, version: 1.0.0, git: "https://github.com/sap/service-fabrik-blueprint-boshrelease.git" }
-          context:
+          context: &context_plan3
             agent: *agent_blueprint
             resource_pool: micro
             disk_pool: hdd_1gb
@@ -438,19 +442,20 @@ defaults: &defaults
         - '1 vCPUs'
         - '1 GB Memory'
         - '1 GB Disk'
-    - id: 'd616b00a-5949-4b1c-bc73-0d3c59f3954a'
+    - &blueprint_plan4
+      id: 'd616b00a-5949-4b1c-bc73-0d3c59f3954a'
       name: 'v1.0-dedicated-large'
       free: false
-      manager:
+      manager: &manager_plan4
         name: 'director'
-        settings:
+        settings: &settings_plan4
           prefix: 'blueprint'
           agent: *agent_blueprint
           update_predecessors:
           - 'bc158c9a-7934-401e-94ab-057082a5073f'
           template: <%= base64_template('blueprint') %>
           releases: *dedicated_releases
-          context:
+          context: &context_plan4
             agent: *agent_blueprint
             resource_pool: micro
             disk_pool: hdd_2gb
@@ -467,10 +472,75 @@ defaults: &defaults
         - '1 GB Memory'
         - '2 GB Disk'
 
-development:
+development: &development
   <<: *defaults
   log_level: debug
   password: 'secret'
+  agents:
+    <<: *agents
+    blueprint: &agent_blueprint1
+      version: '1'
+      hostname: <%= process.env.BLUEPRINT_AGENT_HOSTNAME || '~' %>
+      auth:
+        username: agent
+        password: secret
+      supported_features:
+      - state
+      - lifecycle
+      - credentials
+  services:
+  - <<: *blueprint_service
+    plans:
+    - *blueprint_plan1
+    - *blueprint_plan2
+    - <<: *blueprint_plan3
+      manager:
+        <<: *manager_plan3
+        settings:
+          <<: *settings_plan3
+          agent: *agent_blueprint1
+          context:
+            <<: *context_plan3
+            agent: *agent_blueprint1
+    - <<: *blueprint_plan4
+      manager:
+        <<: *manager_plan4
+        settings:
+          <<: *settings_plan4
+          agent: *agent_blueprint1
+          context:
+            <<: *context_plan4
+            agent: *agent_blueprint1
+
+
+boshlite2:
+  <<: *development
+  log_level: debug
+  password: 'secret'
+  cf:
+    <<: *cf
+    password: 7muomwfzuaqo1r6aid1t
+  director:
+    <<: *director
+    url: https://192.168.50.6:25555
+    password: v5o4z3qg3og1gjct0eea
+    infrastructure:
+      <<: *director_infrastructure
+      networks:
+      - name: default
+        type: manual
+        subnets:
+        - { range: 10.244.11.0/20, az: z1, cloud_properties: { name: random } }
+        - { range: 10.244.12.0/20, az: z2, cloud_properties: { name: random } }
+        - { range: 10.244.13.0/20, az: z3, cloud_properties: { name: random } }
+      - name: compilation
+        type: dynamic
+      compilation:
+        network: compilation
+        reuse_compilation_vms: true
+        workers: 4
+        cloud_properties: { name: random }
+
 
 development_sc6: &sc6
   <<: *defaults


### PR DESCRIPTION
Description: Removes B&R as supported feature for development and add
 support for BOSH2 based deployment

This fix addresses the following details in installation & Setup
of Service Fabrik Broker:

1. Adds help for bosh-deployment based installation.
2. Adds cf-deployment based installation guide.
3. Updates the development mode of settings.yml to remove B&R
and supported feature.
4. Adds boshlite2 mode to override cf and bosh password for BOSH2
 deployment and also to override the network definition.