### PR TITLE
Handle taskId while moving to MultiBOSH

### DIFF
--- a/lib/bosh/BoshDirectorClient.js
+++ b/lib/bosh/BoshDirectorClient.js
@@ -37,6 +37,12 @@ class BoshDirectorClient extends HttpClient {
     this.cache = {};
   }
 
+  static getConfigByName(name) {
+    return _.filter(config.directors, function (director) {
+      return director.name === name;
+    });
+  }
+
   static getInfrastructure() {
     return BoshDirectorClient.getActivePrimary()[0].infrastructure;
   }
@@ -500,6 +506,14 @@ class BoshDirectorClient extends HttpClient {
 
   getTask(taskId) {
     const splitArray = this.parseTaskid(taskId);
+    if (splitArray === null) {
+      return this
+        .makeRequestWithConfig({
+          method: 'GET',
+          url: `/tasks/${taskId}`
+        }, 200, BoshDirectorClient.getConfigByName(CONST.BOSH_DIRECTORS.BOSH))
+        .then(res => JSON.parse(res.body));
+    }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];
     return this
@@ -512,6 +526,23 @@ class BoshDirectorClient extends HttpClient {
 
   getTaskResult(taskId) {
     const splitArray = this.parseTaskid(taskId);
+    if (splitArray === null) {
+      return this
+        .makeRequestWithConfig({
+          method: 'GET',
+          url: `/tasks/${taskId}/output`,
+          qs: {
+            type: 'result'
+          }
+        }, 200, BoshDirectorClient.getConfigByName(CONST.BOSH_DIRECTORS.BOSH))
+        .then(res => _
+          .chain(res.body)
+          .split('\n')
+          .compact()
+          .map(JSON.parse)
+          .value()
+        );
+    }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];
     return this
@@ -533,6 +564,27 @@ class BoshDirectorClient extends HttpClient {
 
   getTaskEvents(taskId) {
     const splitArray = this.parseTaskid(taskId);
+    if (splitArray === null) {
+      return this
+        .makeRequestWithConfig({
+          method: 'GET',
+          url: `/tasks/${taskId}/output`,
+          qs: {
+            type: 'event'
+          }
+        }, 200, BoshDirectorClient.getConfigByName(CONST.BOSH_DIRECTORS.BOSH))
+        .then(res => {
+          let events = [];
+          _.trim(res.body).split('\n').forEach((event) => {
+            try {
+              events.push(JSON.parse(event));
+            } catch (err) {
+              logger.error(`Error parsing task event "${event}": ${err.message}`, err);
+            }
+          });
+          return events;
+        });
+    }
     const deploymentName = splitArray[1];
     const taskIdAlone = splitArray[2];
     return this


### PR DESCRIPTION
* With the new design to handle multi bosh the taskId
  expected from the Cloudcontroller is of the form
  deploymentName_TaskId
* If a task is in progress while the service-fabrik redeploy
  happens with the new code, the taskId will be of the old
  format.
* This change handles this corner case.
* This change is meant to be removed once the move to the MultiBOSH
  setup is completed

Fixes #18 