### PR TITLE
Closes-Bug: #30 Admin api for director config

### DIFF
--- a/lib/controllers/ServiceFabrikAdminController.js
+++ b/lib/controllers/ServiceFabrikAdminController.js
@@ -174,6 +174,20 @@ class ServiceFabrikAdminController extends BaseController {
     this.getDeployments(req, res, true);
   }
 
+  getDeploymentDirectorConfig(req, res) {
+    const deploymentName = req.params.name;
+    return bosh.director
+      .getDirectorConfig(deploymentName)
+      .then(config => res
+        .status(200)
+        .send(config)
+      )
+      .catch(() => res
+        .status(400)
+        .send({})
+      );
+  }
+
   getDeployment(req, res) {
     const deploymentName = req.params.name;
     this.createManager(req.query.plan_id)

--- a/lib/routes/admin.js
+++ b/lib/routes/admin.js
@@ -52,6 +52,9 @@ router.route('/deployments/:name/backup')
 router.route('/deployments/:name/backup/status')
   .get(controller.handler('getLastOobBackupStatus'))
   .all(middleware.methodNotAllowed(['GET']));
+router.route('/deployments/:name/director')
+  .get(controller.handler('getDeploymentDirectorConfig'))
+  .all(middleware.methodNotAllowed(['GET']));
 router.route('/deployments/:name/restore')
   .post(controller.handler('startOobRestore'))
   .get(controller.handler('getOobRestore'))

--- a/test/acceptance/service-fabrik-admin.instances.director.spec.js
+++ b/test/acceptance/service-fabrik-admin.instances.director.spec.js
@@ -79,6 +79,27 @@ describe('service-fabrik-admin', function () {
         });
       });
 
+      describe('#getDeploymentDirectorConfig', function () {
+        it('it return the config of the director to which the deployment belongs', function () {
+          return chai
+            .request(apps.internal)
+            .get(`${base_url}/deployments/${deployment_name}/director`)
+            .set('Accept', 'application/json')
+            .auth(config.username, config.password)
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body.name).to.equal('bosh');
+              expect(res.body).to.have.property('uuid');
+              expect(res.body).to.have.property('name');
+              expect(res.body).to.have.property('support_create');
+              expect(res.body).to.have.property('infrastructure');
+              expect(res.body).to.have.property('cpi');
+              mocks.verify();
+            });
+        });
+      });
+
       describe('#updateDeployment', function () {
         it('should initiate a service-fabrik-operation via an update at cloud controller', function () {
           mocks.cloudController.updateServiceInstance(instance_id, body => {


### PR DESCRIPTION
Description:

With service fabrik now supporting multiple BOSH, there is a need to
find the director for the deployment by using the deployment name.
The code changes in this commit introduces a new admin endpoint

```
/admin/deployments/<deployment_name>/config
```

Which returns the config of the director when a valid deployment is
sent as parameter. Else returns error code of 400 and an empty json.