### PR TITLE
Fix #32 (Deployments in locked state even after successful backup)

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -539,8 +539,8 @@ boshlite2:
   cf:
     <<: *cf
     password: 7muomwfzuaqo1r6aid1t
-  director:
-    <<: *director
+  directors:
+  - <<: *director
     url: https://192.168.50.6:25555
     password: v5o4z3qg3og1gjct0eea
     infrastructure:
@@ -565,8 +565,8 @@ development_sc6: &sc6
   <<: *defaults
   log_level: debug
   password: 'secret'
-  director:
-    <<: *director
+  directors:
+  - <<: *director
     prefix: service-fabrik-backup
     url: https://127.0.0.1:25555
     infrastructure:
@@ -620,8 +620,8 @@ development_aws:
   <<: *defaults
   log_level: debug
   password: 'secret'
-  director:
-    <<: *director
+  directors:
+  - <<: *director
     url: https://127.0.0.1:25557
     infrastructure:
       <<: *director_infrastructure

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -193,6 +193,8 @@ defaults: &defaults
     retention_period_in_days: 14
     max_num_on_demand_backup: 2
     status_check_every: 120000 # (ms) Check the status of backup once every 2 mins
+    retry_delay_on_error: 60000 # (ms) In case of unlock failure 3 retry attempts will be done with this configured delay in exponential manner
+    lock_check_delay_on_restart: 5000 #(ms) On restart of service fabrik queries all deployments to see if there is a lock on it. This delay ensures each call is spaced with this delay.
     backup_restore_status_poller_timeout: 86400000 # (ms) Deployment backup/restore must finish within this timeout time (24 hrs)
     backup_restore_status_check_every: 120000 # (ms) Check the status of deployment backup/restore once every 2 mins
     abort_time_out: 300000 #(ms) Timeout time for abort of backup to complete

--- a/lib/EventLogInterceptor.js
+++ b/lib/EventLogInterceptor.js
@@ -211,29 +211,34 @@ class EventLogInterceptor {
   }
 
   publishAndAuditLogEvent(url, method, request, response, checkResponseBody, instanceType) {
-    const eventConfig = _.clone(this.getEventConfig(url, method));
-    if (eventConfig === undefined) {
-      return undefined;
+    try {
+      const eventConfig = _.clone(this.getEventConfig(url, method));
+      if (eventConfig === undefined) {
+        return undefined;
+      }
+      if (checkResponseBody) {
+        eventConfig.check_res_body = true;
+      }
+      const opStatus = this.getOperationStatus(response, eventConfig, response.body);
+      instanceType = instanceType === undefined ? CONST.INSTANCE_TYPE.DIRECTOR : instanceType;
+      instanceType = instanceType.length > 0 ? `${instanceType}.` : instanceType;
+      const eventInfo = this.getEventInfo(instanceType,
+        eventConfig.event_name,
+        eventConfig.tags,
+        opStatus,
+        request,
+        response.body);
+      pubsub.publish(this.eventType, {
+        event: eventInfo,
+        config: eventConfig
+      });
+      const auditMessage = this.formatAuditMessage(response.statusCode || 200, eventInfo);
+      logger.info(auditMessage);
+      return eventInfo;
+    } catch (err) {
+      //Any errors arising out of logging must not bubble up
+      logger.error(`Error occurred while publishing event for ${url} : ${method}`, err);
     }
-    if (checkResponseBody) {
-      eventConfig.check_res_body = true;
-    }
-    const opStatus = this.getOperationStatus(response, eventConfig, response.body);
-    instanceType = instanceType === undefined ? CONST.INSTANCE_TYPE.DIRECTOR : instanceType;
-    instanceType = instanceType.length > 0 ? `${instanceType}.` : instanceType;
-    const eventInfo = this.getEventInfo(instanceType,
-      eventConfig.event_name,
-      eventConfig.tags,
-      opStatus,
-      request,
-      response.body);
-    pubsub.publish(this.eventType, {
-      event: eventInfo,
-      config: eventConfig
-    });
-    const auditMessage = this.formatAuditMessage(response.statusCode || 200, eventInfo);
-    logger.info(auditMessage);
-    return eventInfo;
   }
 
   formatAuditMessage(httpStatusCode, eventInfo) {

--- a/lib/fabrik/FabrikStatusPoller.js
+++ b/lib/fabrik/FabrikStatusPoller.js
@@ -151,15 +151,19 @@ class FabrikStatusPoller {
                 numberOfSFDeployment++;
                 return Promise
                   .delay(config.backup.lock_check_delay_on_restart * numberOfSFDeployment)
-                  .then(() => bosh
-                    .director
-                    .getLockProperty(deploymentName)
+                  .then(() => utils
+                    .retry(() => bosh
+                      .director
+                      .getLockProperty(deploymentName), {
+                        maxAttempts: 3,
+                        minDelay: config.backup.retry_delay_on_error
+                      })
                     .then(lockInfo => this.startIfNotLocked(lockInfo, operation))
-                    .catch(err => logger.error(`Error occurred while setting poller `, err)));
+                    .catch(err => logger.error(`Error occurred while setting poller for ${deploymentName}`, err)));
               }
             }))
             .catch(errors.Timeout, (err) => {
-              logger.info('Error occurred while fetching deployments ...', err);
+              logger.error('Error occurred while fetching deployments ...', err);
               FabrikStatusPoller.restart('backup');
               //If we have BOSH errors and getDeployment fails even after a retry with exponential backoff, retry all over again.
               return null;

--- a/lib/fabrik/FabrikStatusPoller.js
+++ b/lib/fabrik/FabrikStatusPoller.js
@@ -9,6 +9,7 @@ const logger = require('../logger');
 const ServiceFabrikOperation = require('./ServiceFabrikOperation');
 const bosh = require('../bosh');
 const utils = require('../utils');
+const errors = require('../errors');
 const config = require('../config');
 const CONST = require('../constants');
 const EventLogInterceptor = require('../EventLogInterceptor');
@@ -17,9 +18,11 @@ const serviceFabrikClient = require('../cf').serviceFabrikClient;
 
 class FabrikStatusPoller {
 
-  static start(instanceInfo, operation, user) {
+  static start(instanceInfoInput, operation, user) {
     return Promise
       .try(() => {
+        let instanceInfo = _.cloneDeep(instanceInfoInput);
+        //Since the object maintains the state of poll, cloning it to ensure it cannot be tampered from outside (i.e. caller)
         assert.ok(instanceInfo.instance_guid, `${operation} poll operation must have the property 'instance_guid'`);
         assert.ok(instanceInfo.agent_ip, `${operation} poll operation must have the property 'agent_ip'`);
         assert.ok(instanceInfo.deployment, `${operation} poll operation must have the property 'deployment'`);
@@ -29,24 +32,31 @@ class FabrikStatusPoller {
         assert.ok(instanceInfo.plan_id, `${operation} poll operation must have the property 'plan_id'`);
         assert.ok(instanceInfo.started_at, `${operation} poll operation must have the property 'started_at'`);
         instanceInfo.user = user;
+        instanceInfo.operationFinished = false;
         let abortInitiated = false;
         let abortStartTime;
         const checkStatus = () => {
           logger.info(`Checking ${operation} status for deployment :${instanceInfo.deployment}`);
           const plan = catalog.getPlan(instanceInfo.plan_id);
           let operationResponse;
-          DirectorManager
-            .load(plan)
-            .then(directorManager => directorManager.getServiceFabrikOperationState(operation, instanceInfo))
-            .tap(status => operationResponse = status)
+          return Promise.try(() => {
+              if (instanceInfo.operationFinished) {
+                return true;
+              }
+              return DirectorManager
+                .load(plan)
+                .then(directorManager => directorManager.getServiceFabrikOperationState(operation, instanceInfoInput)) //could have used instanceInfo itself, but for UT setups need this to be passed
+                .tap(status => operationResponse = status);
+            })
             .catch(error => {
-              logger.error(`Error occurred while checking ${operation} status of :${instanceInfo.deployment}`, error);
+              logger.error(`Error occurred while checking ${operation} status of :${instanceInfo.deployment} - for guid: ${instanceInfo.backup_guid}`, error);
             })
             .finally(() => {
-              let operationTimedOut = false;
-              logger.info(`Status of ${operation} operation on : ${instanceInfo.deployment} for guid: ${instanceInfo.backup_guid} - `, operationResponse);
-              let isOperationFinished = operationResponse && utils.isServiceFabrikOperationFinished(operationResponse.state);
-              if (!isOperationFinished) {
+              if (!instanceInfo.operationFinished) {
+                let operationTimedOut = false;
+                logger.info(`Status of ${operation} operation on : ${instanceInfo.deployment} for guid: ${instanceInfo.backup_guid} - `, operationResponse);
+                instanceInfo.operationFinished = operationResponse && utils.isServiceFabrikOperationFinished(operationResponse.state);
+                instanceInfo.operationResponse = _.clone(operationResponse);
                 const currentTime = new Date();
                 const duration = (currentTime - new Date(instanceInfo.started_at)) / 1000;
                 const lock_deployment_max_duration = bosh.director.getDirectorConfig(instanceInfo.deployment).lock_deployment_max_duration;
@@ -68,42 +78,43 @@ class FabrikStatusPoller {
                       logger.info(`backup abort is still in progress on : ${instanceInfo.deployment} for guid : ${instanceInfo.backup_guid}`);
                       return;
                     } else {
-                      operationResponse = _.clone(operationResponse);
-                      operationResponse.state = CONST.OPERATION.ABORTED;
+                      instanceInfo.operationResponse.state = CONST.OPERATION.ABORTED;
                     }
                     logger.info('Abort Backup timed out on : ${instanceInfo.deployment} for guid : ${instanceInfo.backup_guid}. Flagging backup operation as complete');
                   }
-                  isOperationFinished = true;
+                  instanceInfo.operationFinished = true;
                 }
               }
-              if (isOperationFinished) {
-                logger.info('Polling complete.');
+              if (instanceInfo.operationFinished) {
+                logger.info(`Backup complete for guid : ${instanceInfo.backup_guid} -  deployment : ${instanceInfo.deployment} `);
                 const unlockOperation = new ServiceFabrikOperation('unlock', {
                   instance_id: instanceInfo.instance_guid,
                   isOperationSync: true
                 });
-                const eventLogger = EventLogInterceptor.getInstance(config.external.event_type, 'external');
-                const check_res_body = true;
-                const resp = {
-                  statusCode: 200,
-                  body: operationResponse
-                };
-                if (CONST.URL[operation]) {
-                  eventLogger.publishAndAuditLogEvent(CONST.URL[operation], CONST.HTTP_METHOD.POST, instanceInfo, resp, check_res_body);
-                }
-                clearInterval(timer);
-                _.find(this.pollers, (poller, index) => {
-                  if (poller === timer) {
-                    this.pollers.splice(index, 1);
-                    return -1;
-                  }
-                });
                 return utils
                   .retry(() => unlockOperation.invoke(), {
                     maxAttempts: 3,
-                    minDelay: 60000
+                    minDelay: config.backup.retry_delay_on_error
                   })
-                  .then(() => logger.info(`Unlocked instance : ${instanceInfo.instance_guid} - deployment : ${instanceInfo.deployment} successfully`))
+                  .then(() => {
+                    logger.info(`Unlocked deployment : ${instanceInfo.deployment} for backup_guid : ${instanceInfo.backup_guid} successfully. Poller stopped.`);
+                    const eventLogger = EventLogInterceptor.getInstance(config.external.event_type, 'external');
+                    const check_res_body = true;
+                    const resp = {
+                      statusCode: 200,
+                      body: instanceInfo.operationResponse
+                    };
+                    if (CONST.URL[operation]) {
+                      eventLogger.publishAndAuditLogEvent(CONST.URL[operation], CONST.HTTP_METHOD.POST, instanceInfo, resp, check_res_body);
+                    }
+                    clearInterval(timer);
+                    _.find(this.pollers, (poller, index) => {
+                      if (poller === timer) {
+                        this.pollers.splice(index, 1);
+                        return -1;
+                      }
+                    });
+                  })
                   .catch(err => logger.error(`Error occurred while unlocking deployment: ${instanceInfo.deployment} for ${operation} with guid : ${instanceInfo.backup_guid}`, err));
               }
             });
@@ -124,17 +135,38 @@ class FabrikStatusPoller {
 
   static restart(operation) {
     logger.info(`FabrikStatusPoller restart for ${operation}`);
-    return bosh.director
-      .getDeploymentNames(false)
-      .then(deploymentNames => _.map(deploymentNames, deploymentName => {
-        if (utils.deploymentNamesRegExp().test(deploymentName)) {
-          return bosh
-            .director
-            .getLockProperty(deploymentName)
-            .then(lockInfo => this.startIfNotLocked(lockInfo, operation))
-            .catch(err => logger.error(`Error occurred while setting poller `, err));
+    //Introducing a delay at restart as this happens recursively in case BOSH is down
+    return Promise.delay(config.backup.retry_delay_on_error)
+      .then(() => {
+        if (!FabrikStatusPoller.stopPoller) {
+          let numberOfSFDeployment = 0;
+          return utils
+            .retry(() => bosh.director
+              .getDeploymentNames(false), {
+                maxAttempts: 3,
+                minDelay: config.backup.retry_delay_on_error
+              })
+            .then(deploymentNames => _.map(deploymentNames, deploymentName => {
+              if (utils.deploymentNamesRegExp().test(deploymentName)) {
+                numberOfSFDeployment++;
+                return Promise
+                  .delay(config.backup.lock_check_delay_on_restart * numberOfSFDeployment)
+                  .then(() => bosh
+                    .director
+                    .getLockProperty(deploymentName)
+                    .then(lockInfo => this.startIfNotLocked(lockInfo, operation))
+                    .catch(err => logger.error(`Error occurred while setting poller `, err)));
+              }
+            }))
+            .catch(errors.Timeout, (err) => {
+              logger.info('Error occurred while fetching deployments ...', err);
+              FabrikStatusPoller.restart('backup');
+              //If we have BOSH errors and getDeployment fails even after a retry with exponential backoff, retry all over again.
+              return null;
+              //Returning null as unit tests can atleast proceed with verification else they will wait timeout
+            });
         }
-      }));
+      });
   }
 
   static clearAllPollers() {
@@ -146,6 +178,7 @@ class FabrikStatusPoller {
 }
 
 FabrikStatusPoller.pollers = [];
+FabrikStatusPoller.stopPoller = false; //Used mainly from tests. Else, the poller keeps running and other mocks in test suite will suffer
 pubsub.subscribe(CONST.TOPIC.APP_STARTUP, (eventName, eventInfo) => {
   logger.debug('-> Recieved event ->', eventName);
   if (eventInfo.type === 'external') {

--- a/test/fabrik.FabrikStatusPoller.spec.js
+++ b/test/fabrik.FabrikStatusPoller.spec.js
@@ -3,23 +3,25 @@
 const lib = require('../lib');
 const _ = require('lodash');
 const proxyquire = require('proxyquire');
+const logger = require('../lib/logger');
 const DirectorManager = lib.fabrik.DirectorManager;
 const BoshDirectorClient = lib.bosh.BoshDirectorClient;
 const CONST = require('../lib/constants');
+const errors = require('../lib/errors');
 const ServiceFabrikClient = require('../lib/cf/ServiceFabrikClient');
 const ServiceFabrikOperation = require('../lib/fabrik/ServiceFabrikOperation');
 
 describe('fabrik', function () {
   describe('FabrikStatusPoller', function () {
     /* jshint expr:true */
-
     let sandbox, startStub, directorOperationStub, serviceFabrikClientStub, serviceFabrikOperationStub,
-      getDirectorConfigStub;
+      getDirectorConfigStub, failUnlock, restartSpy;
     const index = mocks.director.networkSegmentIndex;
     const time = Date.now();
     const IN_PROGRESS_BACKUP_GUID = '071acb05-66a3-471b-af3c-8bbf1e4180be';
     const SUCCEEDED_BACKUP_GUID = '071acb05-66a3-471b-af3c-8bbf1e4180bs';
     const ABORTING_BACKUP_GUID = '071acb05-66a3-471b-af3c-8bbf1e4180ba';
+    const UNLOCK_FAILED_BACKUP_GUID = '071acb05-66a3-471b-af3c-8bbf1e4180bc';
     const instanceInfo = {
       space_guid: 'e7c0a437-7585-4d75-addf-aa4d45b49f3a',
       instance_guid: mocks.director.uuidByIndex(index),
@@ -35,18 +37,20 @@ describe('fabrik', function () {
     _.set(instanceInfo_Succeeded, 'backup_guid', SUCCEEDED_BACKUP_GUID);
     const instanceInfo_aborting = _.clone(instanceInfo);
     _.set(instanceInfo_aborting, 'backup_guid', ABORTING_BACKUP_GUID);
+    const instanceInfo_unlock_failed = _.clone(instanceInfo);
+    _.set(instanceInfo_unlock_failed, 'backup_guid', UNLOCK_FAILED_BACKUP_GUID);
 
     const directorConfigStub = {
-      lock_deployment_max_duration: 0
+      lock_deployment_max_duration: 30000
     };
-
     const config = {
       backup: {
-        status_check_every: 100,
-        abort_time_out: 180000
+        status_check_every: 50,
+        abort_time_out: 180000,
+        retry_delay_on_error: 100,
+        lock_check_delay_on_restart: 0
       }
     };
-
     const FabrikStatusPoller = proxyquire('../lib/fabrik/FabrikStatusPoller', {
       '../config': config
     });
@@ -56,7 +60,13 @@ describe('fabrik', function () {
         sandbox = sinon.sandbox.create();
         directorOperationStub = sandbox.stub(DirectorManager.prototype, 'getServiceFabrikOperationState');
         serviceFabrikClientStub = sandbox.stub(ServiceFabrikClient.prototype, 'abortLastBackup');
-        serviceFabrikOperationStub = sandbox.stub(ServiceFabrikOperation.prototype, 'invoke');
+        serviceFabrikOperationStub = sandbox.stub(ServiceFabrikOperation.prototype, 'invoke', () => Promise.try(() => {
+          logger.info('Unlock must fail:', failUnlock);
+          if (failUnlock) {
+            throw errors.InternalServerError('Error occurred..');
+          }
+          return {};
+        }));
         getDirectorConfigStub = sandbox.stub(BoshDirectorClient.prototype, 'getDirectorConfig');
         getDirectorConfigStub.withArgs(instanceInfo.deployment).returns(directorConfigStub);
         directorOperationStub.withArgs('backup', instanceInfo_InProgress).returns(Promise.resolve({
@@ -71,12 +81,18 @@ describe('fabrik', function () {
         directorOperationStub.withArgs('backup', instanceInfo_Succeeded).onCall(0).returns(Promise.resolve({
           state: CONST.OPERATION.IN_PROGRESS
         }));
-        directorOperationStub.withArgs('backup', instanceInfo_Succeeded).onCall(1).returns(Promise.resolve({
+        directorOperationStub.returns(Promise.resolve({
           state: CONST.OPERATION.SUCCEEDED
         }));
+        // directorOperationStub.returns();
       });
-
+      beforeEach(function () {
+        directorConfigStub.lock_deployment_max_duration = 0;
+        failUnlock = false;
+        FabrikStatusPoller.stopPoller = false;
+      });
       afterEach(function () {
+        FabrikStatusPoller.stopPoller = true;
         FabrikStatusPoller.clearAllPollers();
         directorOperationStub.reset();
         serviceFabrikClientStub.reset();
@@ -93,7 +109,7 @@ describe('fabrik', function () {
           name: 'hugo',
           email: 'hugo@sap.com'
         }).then(() =>
-          Promise.delay(200).then(() => {
+          Promise.delay(150).then(() => {
             expect(directorOperationStub).to.be.atleastOnce;
             expect(serviceFabrikClientStub).to.be.calledOnce;
             expect(serviceFabrikOperationStub).not.to.be.called;
@@ -105,56 +121,70 @@ describe('fabrik', function () {
           name: 'hugo',
           email: 'hugo@sap.com'
         }).then(() =>
-          Promise.delay(300).then(() => {
+          Promise.delay(150).then(() => {
             expect(directorOperationStub).to.be.atleastOnce;
             expect(serviceFabrikClientStub).to.be.calledOnce;
             expect(serviceFabrikOperationStub).to.be.calledOnce;
             config.backup.abort_time_out = 180000;
           }));
       });
-      it('Abort backup if operation is not complete & post successful abort, unlock deployment', function (done) {
+      it('Abort backup if operation is not complete & post successful abort, unlock deployment', function () {
         return FabrikStatusPoller.start(instanceInfo_aborting, CONST.OPERATION_TYPE.BACKUP, {
           name: 'hugo',
           email: 'hugo@sap.com'
         }).then(() =>
-          Promise.delay(300).then(() => {
+          Promise.delay(200).then(() => {
             expect(directorOperationStub).to.be.atleastOnce;
             expect(serviceFabrikClientStub).to.be.calledOnce;
             expect(serviceFabrikOperationStub).to.be.called;
-            done();
           }));
       });
-      it('Stop polling operation on backup completion &  unlock deployment', function (done) {
+      it('Stop polling operation on backup completion &  unlock deployment', function () {
+        directorConfigStub.lock_deployment_max_duration = 3000;
         return FabrikStatusPoller.start(instanceInfo_Succeeded, CONST.OPERATION_TYPE.BACKUP, {
           name: 'hugo',
           email: 'hugo@sap.com'
         }).then(() =>
-          Promise.delay(300).then(() => {
-            expect(directorOperationStub).to.be.atleastOnce;
-            expect(serviceFabrikClientStub).to.be.calledOnce;
+          Promise.delay(200).then(() => {
+            expect(directorOperationStub).to.be.calledTwice;
+            expect(serviceFabrikClientStub).not.to.be.called;
+            expect(FabrikStatusPoller.pollers.length).to.eql(0);
             expect(serviceFabrikOperationStub).to.be.called;
-            done();
+          }));
+      });
+      it('Unlock failure must continue the poller', function () {
+        failUnlock = true;
+        directorConfigStub.lock_deployment_max_duration = 3000;
+        return FabrikStatusPoller.start(instanceInfo_Succeeded, CONST.OPERATION_TYPE.BACKUP, {
+          name: 'hugo',
+          email: 'hugo@sap.com'
+        }).then(() =>
+          Promise.delay(400).then(() => {
+            expect(directorOperationStub).to.be.calledTwice; //On recieving success response the response is set in instanceInfo
+            expect(serviceFabrikClientStub).not.to.be.called;
+            expect(serviceFabrikOperationStub.callCount > 6).to.eql(true); //Retry for each invocation results in 3 calls. So expect atleast 6 (2 *3) calls
           }));
       });
     });
 
     describe('#PollerRestartOnBrokerRestart', function () {
-
       before(function () {
         startStub = sinon.stub(FabrikStatusPoller, 'start');
+        restartSpy = sinon.spy(FabrikStatusPoller, 'restart');
       });
-
+      beforeEach(function () {
+        FabrikStatusPoller.stopPoller = false;
+      });
       afterEach(function () {
+        FabrikStatusPoller.stopPoller = true;
         FabrikStatusPoller.clearAllPollers();
         startStub.reset();
+        restartSpy.reset();
         mocks.reset();
       });
-
       after(function () {
         startStub.restore();
       });
-
-
       describe('#startIfNotLocked', function () {
         it('It should call start() if deployment is  locked', function () {
           FabrikStatusPoller.startIfNotLocked(true, {});
@@ -165,7 +195,6 @@ describe('fabrik', function () {
           return expect(startStub).not.to.be.called;
         });
       });
-
       describe('#restart', function () {
         it('should restart polling for deployments with lock', function () {
           const queued = false;
@@ -183,7 +212,6 @@ describe('fabrik', function () {
             .then(promises => Promise.all(promises)
               .then(() => expect(startStub).to.be.calledTwice));
         });
-
         it('should not restart polling for deployments without a lock', function () {
           const queued = false;
           const capacity = 2;
@@ -199,6 +227,25 @@ describe('fabrik', function () {
             .restart('backup')
             .then(promises => Promise.all(promises)
               .then(() => expect(startStub).not.to.be.called));
+        });
+        it('If bosh is not responding at start then FabrikPoller must keep on retrying', function () {
+          const queued = false;
+          const capacity = 2;
+          const opts = {
+            queued: queued,
+            capacity: capacity
+          };
+          mocks.director.getDeployments(opts, 500);
+          mocks.director.getDeployments(opts, 500);
+          mocks.director.getDeployments(opts, 500);
+          return FabrikStatusPoller
+            .restart('backup')
+            .then(promises => {
+              mocks.verify();
+              expect(startStub).not.to.be.called;
+              expect(restartSpy).to.be.calledTwice;
+              expect(promises).to.eql(null);
+            });
         });
       });
     });

--- a/test/mocks/director.js
+++ b/test/mocks/director.js
@@ -116,7 +116,7 @@ function getDeploymentNames(capacity, queued, oob) {
   return names;
 }
 
-function getDeployments(opts) {
+function getDeployments(opts, expectedReturnStatusCode) {
   const queued = _.get(opts, 'queued', false);
   const capacity = _.get(opts, 'capacity', NetworkSegmentIndex.capacity());
   const noOfTimes = 1;
@@ -127,7 +127,7 @@ function getDeployments(opts) {
     .map(() => nock(directorUrl)
       .replyContentLength()
       .get('/deployments')
-      .reply(200, deployments));
+      .reply(expectedReturnStatusCode || 200, deployments));
   if (queued) {
     const tasks = _
       .chain()


### PR DESCRIPTION
1. Poller is stopped (or cleared) only on successfully unlocking
deployment.
2. Restart of poller staggers the getLock calls on the deployment
to ensure we dont overload bosh with a huge numbe of getProperty
requests.

closes #32