### PR TITLE
Closes #34 - Circuit breaker not configured for Bosh calls

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -493,6 +493,15 @@ development: &development
   <<: *defaults
   log_level: debug
   password: 'secret'
+  directors:
+  - <<: *director
+    cpi: aws_cpi
+    primary: true
+    support_create: true
+    name: bosh
+    uuid: b7e651e2-3afe-471f-9bca-93048fa591f4
+    infrastructure: &test_infrastructure
+      <<: *director_infrastructure
   agents:
     <<: *agents
     blueprint: &agent_blueprint1
@@ -679,7 +688,7 @@ production:
 test:
   <<: *defaults
   log_level: debug
-  enable_circuit_breaker: false
+  # enable_circuit_breaker: false
   external:
     <<: *external
     protocol: 'http'

--- a/lib/utils/HttpClient.js
+++ b/lib/utils/HttpClient.js
@@ -34,10 +34,10 @@ class HttpClient {
 
   buildCommandFactory(baseUrl) {
     const httpCircuitConfig = _.get(config, `circuit_breaker.http`);
-    if (httpCircuitConfig) {
+    if (baseUrl && httpCircuitConfig) {
       const apiConfig = httpCircuitConfig.apis[baseUrl];
       if (apiConfig === undefined) {
-        logger.warn(` Circuit breaker not defined for URL : ${baseUrl}`);
+        logger.debug(`Circuit breaker not defined for URL : ${baseUrl}`);
         this.commandMap[baseUrl] = -1;
         return;
       }
@@ -82,12 +82,12 @@ class HttpClient {
       .build();
   }
 
-  getCommand(url, httpMethod) {
-    url = _.toLower(url);
+  getCommand(options, httpMethod) {
+    const url = _.toLower(options.url);
     httpMethod = _.toLower(httpMethod);
-    let baseUrl = this.baseUrl;
+    let baseUrl = this.baseUrl || options.baseUrl;
     let path = url;
-    if (this.baseUrl === undefined || url.indexOf('http') !== -1) {
+    if (baseUrl === undefined && url.indexOf('http') !== -1) {
       let urlComponents;
       if (this.PARSED_URL_MAP[url] !== undefined) {
         urlComponents = this.PARSED_URL_MAP[url];
@@ -96,13 +96,14 @@ class HttpClient {
         this.PARSED_URL_MAP[url] = urlComponents;
       }
       baseUrl = _.toLower(`${urlComponents.protocol}//${urlComponents.hostname}:${urlComponents.port}`);
+      logger.silly(`base url : ${baseUrl}, url : ${url}`);
       path = urlComponents.pathname;
-      if (this.commandMap[baseUrl] === undefined) {
-        logger.silly('setting up command factory for url :-', baseUrl);
-        this.buildCommandFactory(baseUrl);
-      }
     }
-    if (this.commandMap[baseUrl]) {
+    if (baseUrl && this.commandMap[baseUrl] === undefined) {
+      logger.debug('setting up command factory for url :-', baseUrl);
+      this.buildCommandFactory(baseUrl);
+    }
+    if (baseUrl && this.commandMap[baseUrl]) {
       if (this.commandMap[baseUrl][_.toLower(`${baseUrl}_${httpMethod}_${path}_circuit`)]) {
         return this.commandMap[baseUrl][_.toLower(`${url}_${httpMethod}_circuit`)];
       } else if (this.commandMap[baseUrl][_.toLower(`${baseUrl}_${httpMethod}_circuit`)]) {
@@ -162,13 +163,13 @@ class HttpClient {
   }
 
   request(options, expectedStatusCode) {
-    const command = this.getCommand(options.url, options.method);
+    const command = this.getCommand(options, options.method);
     if (command) {
       logger.silly(`command config for ${options.url}:`, _.omit(command, 'Promise'));
       return Promise.try(() => command.execute(options, expectedStatusCode));
     }
     if (this.PARSED_URL_MAP[`${options.url}_${options.method}`] === undefined) {
-      logger.warn(`Circuit breaker not defined for : ${this.baseUrl}_${options.url}_${options.method}`);
+      logger.warn(`Circuit breaker not defined for : ${options.url} HTTP Method:${options.method}`);
       this.PARSED_URL_MAP[`${options.url}_${options.method}`] = {};
     }
     return this.invoke(options, expectedStatusCode);


### PR DESCRIPTION
Base URL in BoshDirector client was set for each of the requests which was not handled in HTTPClient's circuit breaker configuration/lookup. This is now fixed.