### PR TITLE
Fixes #38 - Unlock deployment operation is made idempotent

### DIFF
--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -489,17 +489,17 @@ class DirectorManager extends BaseManager {
   }
 
   unlock(opts) {
-    return this.releaseLock(opts.deployment)
-      .tap(info => logger.info('Lock released', info))
-      .then(() => this.getLastBackup(opts.space_guid, opts.instance_guid)
-        .then(result => _
-          .chain(result)
-          .omit('secret', 'agent_ip')
-          .assign({
-            description: `Backup operation for ${opts.deployment} finished with status ${JSON.stringify(result.state)}`,
-          })
-          .value())
-      );
+    const responseMessage = _.get(opts, 'arguments.description') || `Unlocked deployment ${opts.deployment}`;
+    const response = {
+      description: responseMessage
+    };
+    return this
+      .releaseLock(opts.deployment)
+      .then(() => response)
+      .catch((errors.NotFound), () => {
+        logger.info(`Lock already released from deployment - ${opts.deployment}`);
+        return response;
+      });
   }
 
   startBackup(opts) {

--- a/lib/fabrik/FabrikStatusPoller.js
+++ b/lib/fabrik/FabrikStatusPoller.js
@@ -89,7 +89,10 @@ class FabrikStatusPoller {
                 logger.info(`Backup complete for guid : ${instanceInfo.backup_guid} -  deployment : ${instanceInfo.deployment} `);
                 const unlockOperation = new ServiceFabrikOperation('unlock', {
                   instance_id: instanceInfo.instance_guid,
-                  isOperationSync: true
+                  isOperationSync: true,
+                  arguments: {
+                    description: `Backup operation for ${instanceInfo.deployment} finished with status ${instanceInfo.operationResponse.state}`
+                  }
                 });
                 return utils
                   .retry(() => unlockOperation.invoke(), {

--- a/test/mocks/director.js
+++ b/test/mocks/director.js
@@ -314,7 +314,6 @@ function getBindingProperty(binding_id, parameters, deployment, notFound) {
     });
 }
 
-
 function verifyDeploymentLockStatus(deployment, locked, params) {
   const deploymentName = deployment || deploymentNameByIndex(networkSegmentIndex);
   if (!locked) {
@@ -336,11 +335,11 @@ function verifyDeploymentLockStatus(deployment, locked, params) {
     });
 }
 
-function releaseLock(deployment) {
+function releaseLock(deployment, expectedStatusCode) {
   const deploymentName = deployment || deploymentNameByIndex(networkSegmentIndex);
   return nock(directorUrl)
     .delete(`/deployments/${deploymentName}/properties/${CONST.DEPLOYMENT_LOCK_NAME}`)
-    .reply(204);
+    .reply(expectedStatusCode || 204);
 }
 
 function acquireLock(deployment) {


### PR DESCRIPTION
If a unlock request is received on a deployment on which there is
no lock, then such requests are not errored rather they are returned
back successfully

Closes #38