### PR TITLE
Fixes #43 Retrying unlock of deployment leads to a domino effect on BOSH

### DIFF
--- a/lib/bosh/BoshDirectorClient.js
+++ b/lib/bosh/BoshDirectorClient.js
@@ -33,8 +33,13 @@ class BoshDirectorClient extends HttpClient {
     this.populateCache();
   }
 
-  clearCache() {
-    this.cache = {};
+  clearCache(config) {
+    if (config) {
+      logger.info('clearing cache for config - ', config.name);
+      _.each(this.cache, (value, key) => value === config ? delete this.cache[key] : '');
+    } else {
+      this.cache = {};
+    }
   }
 
   static getInfrastructure() {
@@ -64,24 +69,52 @@ class BoshDirectorClient extends HttpClient {
   }
 
   populateCache() {
+    logger.info('Loading Bosh DeploymentName cache... current cached deployments:', _.keys(this.cache));
     this.cacheLoadInProgress = true;
     this.clearCache();
     return Promise
-      .map(config.directors, directorConfig => {
-        return this
-          .getDeploymentsByConfig(directorConfig)
-          .tap(deployments => _.map(deployments, deployment => {
-            if (this.cache[deployment.name] === undefined) {
-              this.cache[deployment.name] = directorConfig;
-            } else {
-              this.cache[deployment.name] = CONST.ERR_CODES.DEPLOYMENT_NAME_DUPED_ACROSS_DIRECTORS;
-            }
-          }));
-      })
-      .tap(() => {
+      .map(config.directors,
+        (directorConfig) => this.getDeploymentsByConfig(directorConfig))
+      .finally(() => {
         this.cacheLoadInProgress = false;
-        logger.debug('Cached Deployments:', _.keys(this.cache));
+        logger.info('Clearing cacheLoadInProgress flag. Bosh DeploymentName cache is loaded.');
+        logger.silly('Cached Deployments:', _.keys(this.cache));
       });
+  }
+
+  getDeploymentNamesFromCache(boshName, attempt) {
+    return Promise.try(() => {
+      if (this.cacheLoadInProgress) {
+        if (!attempt) {
+          attempt = 1;
+        } else if (attempt > CONST.BOSH_POLL_MAX_ATTEMPTS) {
+          throw errors.Timeout.toManyAttempts(CONST.BOSH_POLL_MAX_ATTEMPTS, new Error('Fetching deployments from Cache is taking too long.'));
+        }
+        logger.info(`Cache load in progress. GetDeploymentNames will be delayed by 500 ms - current attempt ${attempt}`);
+        return Promise.delay(500 * attempt).then(() => this.getDeploymentNamesFromCache(boshName, ++attempt));
+      }
+      if (boshName) {
+        const deploymentNames = [];
+        const config = this.getConfigByName(boshName);
+        _.each(this.cache, (value, key) => value === config ? deploymentNames.push(key) : '');
+        return deploymentNames;
+      } else {
+        return _.keys(this.cache);
+      }
+    });
+  }
+
+  updateCache(config, deployments) {
+    return Promise.try(() => {
+      this.clearCache(config);
+      _.map(deployments, deployment => {
+        if (this.cache[deployment.name] === undefined) {
+          this.cache[deployment.name] = config;
+        } else {
+          this.cache[deployment.name] = CONST.ERR_CODES.DEPLOYMENT_NAME_DUPED_ACROSS_DIRECTORS;
+        }
+      });
+    });
   }
 
   deleteCacheEntry(deploymentName) {
@@ -93,15 +126,13 @@ class BoshDirectorClient extends HttpClient {
       logger.debug(`Finding the correct director config for:`, deploymentName);
       const cache_val = this.cache[deploymentName];
       if (cache_val !== undefined) {
-        logger.silly('found director in cache...', cache_val);
+        logger.silly('found director in cache...', cache_val.name);
         return cache_val;
       }
       logger.debug('cache miss for..', deploymentName);
       if (this.cacheLoadInProgress) {
         logger.debug('Cache load in progress.. deferring execution..', this.cacheLoadInProgress);
-        return Promise.delay(100).then(() => {
-          return this.getDirectorConfig(deploymentName);
-        });
+        return Promise.delay(500).then(() => this.getDirectorConfig(deploymentName));
       }
       return this
         .populateCache()
@@ -151,17 +182,44 @@ class BoshDirectorClient extends HttpClient {
         method: 'GET',
         url: '/deployments'
       }, 200, config)
-      .then(res => JSON.parse(res.body));
+      .then(res => JSON.parse(res.body))
+      .tap(deployments => {
+        this.updateCache(config, deployments);
+        logger.info('Updated cache for config - ', config.name);
+      });
   }
 
   getDeployments() {
     return Promise
       .map(this.primaryConfigs, directorConfig => {
         return this
-          .getDeploymentsByConfig(directorConfig)
-          .tap(deployments => _.map(deployments, deployment => this.cache[deployment.name] = directorConfig));
+          .getDeploymentsByConfig(directorConfig);
       })
       .reduce((all_deployments, deployments) => all_deployments.concat(deployments), []);
+  }
+
+  getDeploymentNameForInstanceId(guid) {
+    logger.debug(`Finding deployment name for instance id : '${guid}'`);
+    return Promise.try(() => {
+      const match = _
+        .chain(this.cache)
+        .keys()
+        .filter((name) => _.endsWith(name, guid))
+        .value();
+      if (match.length > 0) {
+        return match[0];
+      }
+      logger.info(`Cache miss for deployment for instance guid ${guid}. Will load all deployment names..`);
+      return this.getDeploymentNames(false)
+        .then(deploymentNames => {
+          const deploymentName = _.find(deploymentNames, name => _.endsWith(name, guid));
+          if (!deploymentName) {
+            logger.warn('+-> Could not find a matching deployment');
+            throw new errors.ServiceInstanceNotFound(guid);
+          }
+          return deploymentName;
+        });
+    });
   }
 
   getDeploymentNames(queued) {
@@ -375,7 +433,7 @@ class BoshDirectorClient extends HttpClient {
 
   pollTaskStatusTillComplete(taskId, pollInterval, timeout, maxErrorRetry) {
     let errorRetries = 0;
-    maxErrorRetry = maxErrorRetry || CONST.BOSH_TASK_POLL_MAX_ATTEMPTS;
+    maxErrorRetry = maxErrorRetry || CONST.BOSH_POLL_MAX_ATTEMPTS;
     return new Promise((resolve, reject) => {
       const startTime = Date.now();
       logger.debug('will query state for task :', taskId);

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,7 +2,7 @@
 
 module.exports = Object.freeze({
   NETWORK_SEGMENT_LENGTH: 4,
-  BOSH_TASK_POLL_MAX_ATTEMPTS: 3,
+  BOSH_POLL_MAX_ATTEMPTS: 3,
   DEPLOYMENT_LOCK_NAME: '_LOCK_',
   SERVICE_FABRIK_PREFIX: 'service-fabrik',
   OPERATION: {

--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -21,7 +21,6 @@ const NotFound = errors.NotFound;
 const BadRequest = errors.BadRequest;
 const NotImplemented = errors.NotImplemented;
 const ServiceInstanceAlreadyExists = errors.ServiceInstanceAlreadyExists;
-const ServiceInstanceNotFound = errors.ServiceInstanceNotFound;
 const ServiceInstanceNotOperational = errors.ServiceInstanceNotOperational;
 const FeatureNotSupportedByAnyAgent = errors.FeatureNotSupportedByAnyAgent;
 const ServiceBindingAlreadyExists = errors.ServiceBindingAlreadyExists;

--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -115,15 +115,10 @@ class DirectorManager extends BaseManager {
 
   findNetworkSegmentIndex(guid) {
     logger.info(`Finding network segment index of an existing deployment with instance id '${guid}'...`);
-    return this.getDeploymentNames(false)
-      .then(deploymentNames => {
-        const deploymentName = _.find(deploymentNames, name => _.endsWith(name, guid));
-        if (!deploymentName) {
-          logger.warn('+-> Could not find a matching deployment');
-          throw new ServiceInstanceNotFound(guid);
-        }
-        return this.getNetworkSegmentIndex(deploymentName);
-      })
+    return this
+      .director
+      .getDeploymentNameForInstanceId(guid)
+      .then(deploymentName => this.getNetworkSegmentIndex(deploymentName))
       .tap(networkSegmentIndex => logger.info(`+-> Found network segment index '${networkSegmentIndex}'`));
   }
 

--- a/lib/fabrik/FabrikStatusPoller.js
+++ b/lib/fabrik/FabrikStatusPoller.js
@@ -35,89 +35,95 @@ class FabrikStatusPoller {
         instanceInfo.operationFinished = false;
         let abortInitiated = false;
         let abortStartTime;
+        let checkStatusOperationInProgress = false;
         const checkStatus = () => {
-          logger.info(`Checking ${operation} status for deployment :${instanceInfo.deployment}`);
-          const plan = catalog.getPlan(instanceInfo.plan_id);
-          let operationResponse;
+          if (checkStatusOperationInProgress) {
+            logger.info(`Previous run of ${operation} status check for deployment :${instanceInfo.deployment} is still in progress. Will skip current poll`);
+            return Promise.resolve({});
+          }
           return Promise.try(() => {
-              if (instanceInfo.operationFinished) {
-                return true;
-              }
-              return DirectorManager
-                .load(plan)
-                .then(directorManager => directorManager.getServiceFabrikOperationState(operation, instanceInfoInput)) //could have used instanceInfo itself, but for UT setups need this to be passed
-                .tap(status => operationResponse = status);
-            })
-            .catch(error => {
-              logger.error(`Error occurred while checking ${operation} status of :${instanceInfo.deployment} - for guid: ${instanceInfo.backup_guid}`, error);
-            })
-            .finally(() => {
-              if (!instanceInfo.operationFinished) {
-                let operationTimedOut = false;
-                logger.info(`Status of ${operation} operation on : ${instanceInfo.deployment} for guid: ${instanceInfo.backup_guid} - `, operationResponse);
-                instanceInfo.operationFinished = operationResponse && utils.isServiceFabrikOperationFinished(operationResponse.state);
-                instanceInfo.operationResponse = _.clone(operationResponse);
-                const currentTime = new Date();
-                const duration = (currentTime - new Date(instanceInfo.started_at)) / 1000;
-                const lock_deployment_max_duration = bosh.director.getDirectorConfig(instanceInfo.deployment).lock_deployment_max_duration;
-                logger.info(`Lock duration : ${duration} / ${lock_deployment_max_duration} (secs) - for ${operation} on : ${instanceInfo.deployment} for guid : ${instanceInfo.backup_guid}`);
-                if (duration > lock_deployment_max_duration) {
-                  operationTimedOut = true;
-                }
-                if (operationTimedOut) {
-                  logger.info(`${operation} operation on deployment - ${instanceInfo.deployment} timedout`);
-                  if (operation === CONST.OPERATION_TYPE.BACKUP) {
-                    if (!abortInitiated) {
-                      logger.info(`Aborting Backup due to time out on : ${instanceInfo.deployment} for guid: ${instanceInfo.backup_guid}`);
-                      abortInitiated = true;
-                      abortStartTime = new Date();
-                      return serviceFabrikClient.abortLastBackup(_.pick(instanceInfo, ['instance_guid', 'space_guid']));
-                    }
-                    const abortDuration = (currentTime - abortStartTime);
-                    if (abortDuration < config.backup.abort_time_out) {
-                      logger.info(`backup abort is still in progress on : ${instanceInfo.deployment} for guid : ${instanceInfo.backup_guid}`);
-                      return;
-                    } else {
-                      instanceInfo.operationResponse.state = CONST.OPERATION.ABORTED;
-                    }
-                    logger.info('Abort Backup timed out on : ${instanceInfo.deployment} for guid : ${instanceInfo.backup_guid}. Flagging backup operation as complete');
+              checkStatusOperationInProgress = true;
+              logger.info(`Checking ${operation} status for deployment :${instanceInfo.deployment}`);
+              const plan = catalog.getPlan(instanceInfo.plan_id);
+              let operationResponse;
+              return Promise.try(() => {
+                  if (instanceInfo.operationFinished) {
+                    return true;
                   }
-                  instanceInfo.operationFinished = true;
-                }
-              }
-              if (instanceInfo.operationFinished) {
-                logger.info(`Backup complete for guid : ${instanceInfo.backup_guid} -  deployment : ${instanceInfo.deployment} `);
-                const unlockOperation = new ServiceFabrikOperation('unlock', {
-                  instance_id: instanceInfo.instance_guid,
-                  isOperationSync: true
-                });
-                return utils
-                  .retry(() => unlockOperation.invoke(), {
-                    maxAttempts: 3,
-                    minDelay: config.backup.retry_delay_on_error
-                  })
-                  .then(() => {
-                    logger.info(`Unlocked deployment : ${instanceInfo.deployment} for backup_guid : ${instanceInfo.backup_guid} successfully. Poller stopped.`);
-                    const eventLogger = EventLogInterceptor.getInstance(config.external.event_type, 'external');
-                    const check_res_body = true;
-                    const resp = {
-                      statusCode: 200,
-                      body: instanceInfo.operationResponse
-                    };
-                    if (CONST.URL[operation]) {
-                      eventLogger.publishAndAuditLogEvent(CONST.URL[operation], CONST.HTTP_METHOD.POST, instanceInfo, resp, check_res_body);
+                  return DirectorManager
+                    .load(plan)
+                    .then(directorManager => directorManager.getServiceFabrikOperationState(operation, instanceInfoInput)) //could have used instanceInfo itself, but for UT setups need this to be passed
+                    .tap(status => operationResponse = status);
+                })
+                .catch(error => {
+                  logger.error(`Error occurred while checking ${operation} status of :${instanceInfo.deployment} - for guid: ${instanceInfo.backup_guid}`, error);
+                })
+                .finally(() => {
+                  if (!instanceInfo.operationFinished) {
+                    let operationTimedOut = false;
+                    logger.info(`Status of ${operation} operation on : ${instanceInfo.deployment} for guid: ${instanceInfo.backup_guid} - `, operationResponse);
+                    instanceInfo.operationFinished = operationResponse && utils.isServiceFabrikOperationFinished(operationResponse.state);
+                    instanceInfo.operationResponse = _.clone(operationResponse);
+                    const currentTime = new Date();
+                    const duration = (currentTime - new Date(instanceInfo.started_at)) / 1000;
+                    const lock_deployment_max_duration = bosh.director.getDirectorConfig(instanceInfo.deployment).lock_deployment_max_duration;
+                    logger.info(`Lock duration : ${duration} / ${lock_deployment_max_duration} (secs) - for ${operation} on : ${instanceInfo.deployment} for guid : ${instanceInfo.backup_guid}`);
+                    if (duration > lock_deployment_max_duration) {
+                      operationTimedOut = true;
                     }
-                    clearInterval(timer);
-                    _.find(this.pollers, (poller, index) => {
-                      if (poller === timer) {
-                        this.pollers.splice(index, 1);
-                        return -1;
+                    if (operationTimedOut) {
+                      logger.info(`${operation} operation on deployment - ${instanceInfo.deployment} timedout`);
+                      if (operation === CONST.OPERATION_TYPE.BACKUP) {
+                        if (!abortInitiated) {
+                          logger.info(`Aborting Backup due to time out on : ${instanceInfo.deployment} for guid: ${instanceInfo.backup_guid}`);
+                          abortInitiated = true;
+                          abortStartTime = new Date();
+                          return serviceFabrikClient.abortLastBackup(_.pick(instanceInfo, ['instance_guid', 'space_guid']));
+                        }
+                        const abortDuration = (currentTime - abortStartTime);
+                        if (abortDuration < config.backup.abort_time_out) {
+                          logger.info(`backup abort is still in progress on : ${instanceInfo.deployment} for guid : ${instanceInfo.backup_guid}`);
+                          return;
+                        } else {
+                          instanceInfo.operationResponse.state = CONST.OPERATION.ABORTED;
+                        }
+                        logger.info('Abort Backup timed out on : ${instanceInfo.deployment} for guid : ${instanceInfo.backup_guid}. Flagging backup operation as complete');
                       }
+                      instanceInfo.operationFinished = true;
+                    }
+                  }
+                  if (instanceInfo.operationFinished) {
+                    logger.info(`Backup complete for guid : ${instanceInfo.backup_guid} -  deployment : ${instanceInfo.deployment} `);
+                    const unlockOperation = new ServiceFabrikOperation('unlock', {
+                      instance_id: instanceInfo.instance_guid,
+                      isOperationSync: true
                     });
-                  })
-                  .catch(err => logger.error(`Error occurred while unlocking deployment: ${instanceInfo.deployment} for ${operation} with guid : ${instanceInfo.backup_guid}`, err));
-              }
-            });
+                    return unlockOperation
+                      .invoke()
+                      .then(() => {
+                        logger.info(`Unlocked deployment : ${instanceInfo.deployment} for backup_guid : ${instanceInfo.backup_guid} successfully. Poller stopped.`);
+                        const eventLogger = EventLogInterceptor.getInstance(config.external.event_type, 'external');
+                        const check_res_body = true;
+                        const resp = {
+                          statusCode: 200,
+                          body: instanceInfo.operationResponse
+                        };
+                        if (CONST.URL[operation]) {
+                          eventLogger.publishAndAuditLogEvent(CONST.URL[operation], CONST.HTTP_METHOD.POST, instanceInfo, resp, check_res_body);
+                        }
+                        clearInterval(timer);
+                        _.find(this.pollers, (poller, index) => {
+                          if (poller === timer) {
+                            this.pollers.splice(index, 1);
+                            return -1;
+                          }
+                        });
+                      })
+                      .catch(err => logger.error(`Error occurred while unlocking deployment: ${instanceInfo.deployment} for ${operation} with guid : ${instanceInfo.backup_guid}`, err));
+                  }
+                });
+            })
+            .finally(() => checkStatusOperationInProgress = false);
         };
         logger.info(`Polling ${operation} status for deployment :${instanceInfo.deployment} - set every ${config.backup.status_check_every} (ms)`);
         const timer = setInterval(checkStatus,
@@ -142,7 +148,7 @@ class FabrikStatusPoller {
           let numberOfSFDeployment = 0;
           return utils
             .retry(() => bosh.director
-              .getDeploymentNames(false), {
+              .getDeploymentNamesFromCache(), {
                 maxAttempts: 3,
                 minDelay: config.backup.retry_delay_on_error
               })

--- a/lib/utils/HttpClient.js
+++ b/lib/utils/HttpClient.js
@@ -142,7 +142,10 @@ class HttpClient {
           err = new BadRequest(message);
           break;
         case 404:
-          logger.debug(message);
+          logger.info(message, {
+            request: options,
+            response: result
+          });
           err = new NotFound(message);
           break;
         default:

--- a/test/fabrik.DirectorManager.spec.js
+++ b/test/fabrik.DirectorManager.spec.js
@@ -21,6 +21,9 @@ var boshStub = {
   director: {
     getDeploymentNames: function () {
       return Promise.resolve([`service-fabrik-0021-${used_guid}`]);
+    },
+    getDeploymentNameForInstanceId: function () {
+      return Promise.resolve([`service-fabrik-0021-${used_guid}`]);
     }
   }
 };

--- a/test/fabrik.FabrikStatusPoller.spec.js
+++ b/test/fabrik.FabrikStatusPoller.spec.js
@@ -236,13 +236,7 @@ describe('fabrik', function () {
               .then(() => expect(startStub).not.to.be.called));
         });
         it('If bosh is not responding at start then FabrikPoller must keep on retrying', function () {
-          const queued = false;
           deploymentFoundInCache = false;
-          const capacity = 2;
-          const opts = {
-            queued: queued,
-            capacity: capacity
-          };
           return FabrikStatusPoller
             .restart('backup')
             .then(promises => {

--- a/test/fabrik.FabrikStatusPoller.spec.js
+++ b/test/fabrik.FabrikStatusPoller.spec.js
@@ -159,30 +159,44 @@ describe('fabrik', function () {
           name: 'hugo',
           email: 'hugo@sap.com'
         }).then(() =>
-          Promise.delay(400).then(() => {
+          Promise.delay(200).then(() => {
             expect(directorOperationStub).to.be.calledTwice; //On recieving success response the response is set in instanceInfo
             expect(serviceFabrikClientStub).not.to.be.called;
-            expect(serviceFabrikOperationStub.callCount > 6).to.eql(true); //Retry for each invocation results in 3 calls. So expect atleast 6 (2 *3) calls
+            expect(serviceFabrikOperationStub.callCount >= 2).to.eql(true); //Retry for each invocation results in 3 calls. So expect atleast 6 (2 *3) calls
           }));
       });
     });
 
     describe('#PollerRestartOnBrokerRestart', function () {
+      let getDeploymentNameFromCacheStub, deploymentFoundInCache;
+      let deployments = [];
+      deployments.push(mocks.director.deploymentNameByIndex(1));
+      deployments.push(mocks.director.deploymentNameByIndex(2));
       before(function () {
         startStub = sinon.stub(FabrikStatusPoller, 'start');
         restartSpy = sinon.spy(FabrikStatusPoller, 'restart');
+        getDeploymentNameFromCacheStub = sinon.stub(BoshDirectorClient.prototype, 'getDeploymentNamesFromCache', () => Promise.try(() => {
+          logger.info('Deployments found in cache:', deploymentFoundInCache);
+          if (deploymentFoundInCache) {
+            return deployments;
+          }
+          throw errors.Timeout.toManyAttempts(CONST.BOSH_POLL_MAX_ATTEMPTS, new Error('Fetching deployments from Cache is taking too long.'));
+        }));
       });
       beforeEach(function () {
+        deploymentFoundInCache = true;
         FabrikStatusPoller.stopPoller = false;
       });
       afterEach(function () {
         FabrikStatusPoller.stopPoller = true;
         FabrikStatusPoller.clearAllPollers();
         startStub.reset();
+        getDeploymentNameFromCacheStub.reset();
         restartSpy.reset();
         mocks.reset();
       });
       after(function () {
+        getDeploymentNameFromCacheStub.restore();
         startStub.restore();
       });
       describe('#startIfNotLocked', function () {
@@ -197,16 +211,9 @@ describe('fabrik', function () {
       });
       describe('#restart', function () {
         it('should restart polling for deployments with lock', function () {
-          const queued = false;
-          const capacity = 2;
-          const opts = {
-            queued: queued,
-            capacity: capacity
-          };
           _.each(
-            mocks.director.getDeploymentNames(capacity, queued), deploymentObj =>
-            mocks.director.getLockProperty(deploymentObj.name, true));
-          mocks.director.getDeployments(opts);
+            deployments, name =>
+            mocks.director.getLockProperty(name, true));
           return FabrikStatusPoller
             .restart('backup')
             .then(promises => Promise.all(promises)
@@ -220,8 +227,8 @@ describe('fabrik', function () {
             capacity: capacity
           };
           _.each(
-            mocks.director.getDeploymentNames(capacity, queued), deploymentObj =>
-            mocks.director.getLockProperty(deploymentObj.name, false));
+            deployments, name =>
+            mocks.director.getLockProperty(name, false));
           mocks.director.getDeployments(opts);
           return FabrikStatusPoller
             .restart('backup')
@@ -230,18 +237,15 @@ describe('fabrik', function () {
         });
         it('If bosh is not responding at start then FabrikPoller must keep on retrying', function () {
           const queued = false;
+          deploymentFoundInCache = false;
           const capacity = 2;
           const opts = {
             queued: queued,
             capacity: capacity
           };
-          mocks.director.getDeployments(opts, 500);
-          mocks.director.getDeployments(opts, 500);
-          mocks.director.getDeployments(opts, 500);
           return FabrikStatusPoller
             .restart('backup')
             .then(promises => {
-              mocks.verify();
               expect(startStub).not.to.be.called;
               expect(restartSpy).to.be.calledTwice;
               expect(promises).to.eql(null);

--- a/test/jobs.ScheduledOobDeploymentBackupJob.spec.js
+++ b/test/jobs.ScheduledOobDeploymentBackupJob.spec.js
@@ -134,7 +134,6 @@ describe('Jobs', function () {
         } catch (ex) {
           console.log('exception occurred', ex);
           mocks.verify();
-          done();
         }
       });
 

--- a/test/jobs.ScheduledOobDeploymentBackupJob.spec.js
+++ b/test/jobs.ScheduledOobDeploymentBackupJob.spec.js
@@ -84,7 +84,7 @@ describe('Jobs', function () {
     });
 
     describe('#RunBackup', function () {
-      it('should initiate deployment backup, delete scheduled backup older than 14 days & backup operation status is succesful', function (done) {
+      it('should initiate deployment backup, delete scheduled backup older than 14 days & backup operation status is succesful', function () {
         const token = utils.encodeBase64({
           backup_guid: backup_guid,
           agent_ip: mocks.agent.ip,
@@ -109,28 +109,28 @@ describe('Jobs', function () {
         try {
           const old_frequency = config.backup.backup_restore_status_check_every;
           config.backup.backup_restore_status_check_every = 200;
-          return ScheduledOobDeploymentBackupJob.run(job, () => {
-            mocks.verify();
-            const expectedBackupResponse = {
-              start_backup_status: {
-                operation: 'backup',
-                backup_guid: backupResponse.backup_guid,
-                token: token
-              },
-              delete_backup_status: {
-                deleted_guids: ['071acb05-66a3-471b-af3c-8bbf1e4180be'],
-                job_cancelled: false,
-                deployment_deleted: false
-              }
-            };
-            config.backup.backup_restore_status_check_every = old_frequency;
-            expect(baseJobLogRunHistoryStub).to.be.calledOnce;
-            expect(baseJobLogRunHistoryStub.firstCall.args[0]).to.eql(undefined);
-            expect(_.omit(baseJobLogRunHistoryStub.firstCall.args[1], 'status', 'deleted_guids')).to.eql(expectedBackupResponse);
-            expect(baseJobLogRunHistoryStub.firstCall.args[2].attrs).to.eql(job.attrs);
-            expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
-            done();
-          });
+          return ScheduledOobDeploymentBackupJob.run(job, () => {})
+            .then(() => {
+              mocks.verify();
+              const expectedBackupResponse = {
+                start_backup_status: {
+                  operation: 'backup',
+                  backup_guid: backupResponse.backup_guid,
+                  token: token
+                },
+                delete_backup_status: {
+                  deleted_guids: ['071acb05-66a3-471b-af3c-8bbf1e4180be'],
+                  job_cancelled: false,
+                  deployment_deleted: false
+                }
+              };
+              config.backup.backup_restore_status_check_every = old_frequency;
+              expect(baseJobLogRunHistoryStub).to.be.calledOnce;
+              expect(baseJobLogRunHistoryStub.firstCall.args[0]).to.eql(undefined);
+              expect(_.omit(baseJobLogRunHistoryStub.firstCall.args[1], 'status', 'deleted_guids')).to.eql(expectedBackupResponse);
+              expect(baseJobLogRunHistoryStub.firstCall.args[2].attrs).to.eql(job.attrs);
+              expect(baseJobLogRunHistoryStub.firstCall.args[3]).to.eql(undefined);
+            });
         } catch (ex) {
           console.log('exception occurred', ex);
           mocks.verify();

--- a/test/mocks/director.js
+++ b/test/mocks/director.js
@@ -120,7 +120,7 @@ function getDeployments(opts, expectedReturnStatusCode) {
   const queued = _.get(opts, 'queued', false);
   const capacity = _.get(opts, 'capacity', NetworkSegmentIndex.capacity());
   const noOfTimes = 1;
-  const oob = _.get(opts, 'oob', false);
+  const oob = _.get(opts, 'oob', true);
   const deployments = getDeploymentNames(capacity, queued, oob);
   const scope = _
     .range(noOfTimes)


### PR DESCRIPTION
On unlock error, retry is implemented. However if BOSH is already down
performing unlock operation results in a CF UPDATE which internally
invokes /getDeployments on BOSH which is an expensive call. The fix is:
1. Stop retry of unlock operation in individual run of poller
2. Find deploymentName for the instance Id initially in the BOSH cache
and then if there is a cache miss goto BOSH to getDeployments
3. FabrikStatusPoller also gets all the deploymentNames from the BOSH Cache

Closes #43