### PR TITLE
Closes issue #47: BoshDirectorClient cache loading has issues in case of errors

### DIFF
--- a/lib/bosh/BoshDirectorClient.js
+++ b/lib/bosh/BoshDirectorClient.js
@@ -75,6 +75,9 @@ class BoshDirectorClient extends HttpClient {
     return Promise
       .map(config.directors,
         (directorConfig) => this.getDeploymentsByConfig(directorConfig))
+      .catch(err => {
+        logger.error('Error occurred while fetching deployments & populating cache : ', err);
+      })
       .finally(() => {
         this.cacheLoadInProgress = false;
         logger.info('Clearing cacheLoadInProgress flag. Bosh DeploymentName cache is loaded.');


### PR DESCRIPTION
Description:  Catching all errors in populateCache method and then setting the flag this.cacheLoadInProgress to false.