### PR TITLE
Closes #50: Provision prameter to choose BOSH

### DIFF
--- a/lib/bosh/BoshDirectorClient.js
+++ b/lib/bosh/BoshDirectorClient.js
@@ -304,7 +304,13 @@ class BoshDirectorClient extends HttpClient {
   createOrUpdateDeployment(manifest, opts) {
     const query = opts ? _.pick(opts, 'recreate', 'skip_drain', 'context') : undefined;
     const deploymentName = yaml.safeLoad(manifest).name;
-    const config = _.sample(this.activePrimary);
+    const boshDirectorName = _.get(opts, 'parameters.bosh_director_name');
+    let config;
+    if (boshDirectorName) {
+      config = this.getConfigByName(boshDirectorName);
+    } else {
+      config = _.sample(this.activePrimary);
+    }
     if (config === undefined || config.length === 0) {
       throw new errors.NotFound('Did not find any bosh director config which supports creation of deployment');
     }

--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -168,6 +168,7 @@ class DirectorManager extends BaseManager {
     const previousValues = _.get(params, 'previous_values');
     const action = _.isPlainObject(previousValues) ? 'update' : 'create';
     const opts = _.omit(params, 'previous_values');
+    args = _.assign(args, _.pick(params, 'parameters'));
     logger.info(`Starting to ${action} deployment '${deploymentName}'...`);
     return Promise
       .try(() => {

--- a/test/acceptance/service-broker-api.instances.director.spec.js
+++ b/test/acceptance/service-broker-api.instances.director.spec.js
@@ -107,6 +107,41 @@ describe('service-broker-api', function () {
               mocks.verify();
             });
         });
+        it('returns 202 Accepted when invoked with bosh name', function () {
+          mocks.director.getDeployments({
+            queued: true
+          });
+          mocks.director.createOrUpdateDeployment(task_id);
+          return chai.request(app)
+            .put(`${base_url}/service_instances/${instance_id}`)
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .send({
+              service_id: service_id,
+              plan_id: plan_id,
+              organization_guid: organization_guid,
+              space_guid: space_guid,
+              parameters: {
+                bosh_director_name: 'bosh'
+              },
+              accepts_incomplete: accepts_incomplete
+            })
+            .then(res => {
+              expect(res).to.have.status(202);
+              expect(res.body.dashboard_url).to.equal(dashboard_url);
+              expect(res.body).to.have.property('operation');
+              const decoded = utils.decodeBase64(res.body.operation);
+              expect(_.pick(decoded, ['type', 'parameters', 'space_guid'])).to.eql({
+                type: 'create',
+                parameters: {
+                  bosh_director_name: 'bosh'
+                },
+                space_guid: space_guid
+              });
+              expect(decoded.task_id).to.eql(`${deployment_name}_${task_id}`);
+              mocks.verify();
+            });
+        });
       });
 
       describe('#update', function () {


### PR DESCRIPTION
This commit enables service-fabrik-broker to recognize json parameter
passed to `cf create-service` command.

```
{
  bosh_director_name: <bosh>
}
```

This bosh_director_name if provided is used to chose the bosh where the
deployment is to be created.
If no director_name is provided the defatult bosh is used for create.