### PR TITLE
Closes #50 #52

### DIFF
--- a/lib/bosh/BoshDirectorClient.js
+++ b/lib/bosh/BoshDirectorClient.js
@@ -304,7 +304,13 @@ class BoshDirectorClient extends HttpClient {
   createOrUpdateDeployment(manifest, opts) {
     const query = opts ? _.pick(opts, 'recreate', 'skip_drain', 'context') : undefined;
     const deploymentName = yaml.safeLoad(manifest).name;
-    const config = _.sample(this.activePrimary);
+    const boshDirectorName = _.get(opts, 'parameters.bosh_director_name');
+    let config;
+    if (boshDirectorName) {
+      config = this.getConfigByName(boshDirectorName);
+    } else {
+      config = _.sample(this.activePrimary);
+    }
     if (config === undefined || config.length === 0) {
       throw new errors.NotFound('Did not find any bosh director config which supports creation of deployment');
     }

--- a/lib/bosh/BoshDirectorClient.js
+++ b/lib/bosh/BoshDirectorClient.js
@@ -305,30 +305,39 @@ class BoshDirectorClient extends HttpClient {
     const query = opts ? _.pick(opts, 'recreate', 'skip_drain', 'context') : undefined;
     const deploymentName = yaml.safeLoad(manifest).name;
     const boshDirectorName = _.get(opts, 'parameters.bosh_director_name');
-    let config;
-    if (boshDirectorName) {
-      config = this.getConfigByName(boshDirectorName);
-    } else {
-      config = _.sample(this.activePrimary);
-    }
-    if (config === undefined || config.length === 0) {
-      throw new errors.NotFound('Did not find any bosh director config which supports creation of deployment');
-    }
-    return this
-      .makeRequestWithConfig({
-        method: 'POST',
-        url: '/deployments',
-        headers: {
-          'Content-Type': 'text/yaml'
-        },
-        qs: query,
-        body: _.isObject(manifest) ? yaml.safeDump(manifest) : manifest
-      }, 302, config)
-      .tap(() => {
-        logger.info(`Cached ${deploymentName} at director: ${config.name} ${config.url}`);
-        this.cache[deploymentName] = config;
+    return Promise.try(() => {
+        if (boshDirectorName) {
+          logger.info(`Deploying through ${boshDirectorName}`);
+          return this.getConfigByName(boshDirectorName);
+        } else {
+          return this
+            .getDirectorConfig(deploymentName) // if update
+            .catch(() => _.sample(this.activePrimary)); // if create
+        }
       })
-      .then(res => this.prefixTaskId(deploymentName, res));
+      .then(config => {
+        if (config === undefined || config.length === 0) {
+          throw new errors.NotFound('Did not find any bosh director config which supports creation of deployment');
+        }
+        return config;
+      })
+      .then((config) => {
+        return this
+          .makeRequestWithConfig({
+            method: 'POST',
+            url: '/deployments',
+            headers: {
+              'Content-Type': 'text/yaml'
+            },
+            qs: query,
+            body: _.isObject(manifest) ? yaml.safeDump(manifest) : manifest
+          }, 302, config)
+          .tap(() => {
+            logger.info(`Cached ${deploymentName} at director: ${config.name} ${config.url}`);
+            this.cache[deploymentName] = config;
+          })
+          .then(res => this.prefixTaskId(deploymentName, res));
+      });
   }
 
   deleteDeployment(deploymentName) {

--- a/lib/bosh/BoshDirectorClient.js
+++ b/lib/bosh/BoshDirectorClient.js
@@ -304,24 +304,28 @@ class BoshDirectorClient extends HttpClient {
   createOrUpdateDeployment(manifest, opts) {
     const query = opts ? _.pick(opts, 'recreate', 'skip_drain', 'context') : undefined;
     const deploymentName = yaml.safeLoad(manifest).name;
-    const boshDirectorName = _.get(opts, 'parameters.bosh_director_name');
+    const boshDirectorName = _.get(opts, 'bosh_director_name');
     return Promise.try(() => {
         if (boshDirectorName) {
-          logger.info(`Deploying through ${boshDirectorName}`);
-          return this.getConfigByName(boshDirectorName);
+          logger.warn(`Deploying through ${boshDirectorName}`);
+          return this
+            .getDirectorConfig(deploymentName)
+            .then(config => {
+              if (config) {
+                throw new BadRequest(`Cannot create an existing deployment ${deploymentName}`);
+              }
+            })
+            .catch(NotFound, () => this.getConfigByName(boshDirectorName));
         } else {
           return this
             .getDirectorConfig(deploymentName) // if update
             .catch(() => _.sample(this.activePrimary)); // if create
         }
       })
-      .then(config => {
+      .then((config) => {
         if (config === undefined || config.length === 0) {
           throw new errors.NotFound('Did not find any bosh director config which supports creation of deployment');
         }
-        return config;
-      })
-      .then((config) => {
         return this
           .makeRequestWithConfig({
             method: 'POST',

--- a/lib/cf/UaaClient.js
+++ b/lib/cf/UaaClient.js
@@ -91,6 +91,16 @@ class UaaClient extends HttpClient {
     });
   }
 
+  getScope(username, password) {
+    return this
+      .accessWithPassword(username, password)
+      .then(resp => _
+        .chain(resp)
+        .get('scope')
+        .split(' ')
+        .value()
+      );
+  }
 
   accessWithPassword(username, password) {
     return this.request({

--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -6,6 +6,7 @@ const config = require('../config');
 const logger = require('../logger');
 const errors = require('../errors');
 const bosh = require('../bosh');
+const cf = require('../cf');
 const backupStore = require('../iaas').backupStore;
 const utils = require('../utils');
 const Agent = require('./Agent');
@@ -185,6 +186,21 @@ class DirectorManager extends BaseManager {
             );
         default:
           return;
+        }
+      })
+      .then(() => {
+        const username = _.get(args, 'parameters.username');
+        const password = _.get(args, 'parameters.password');
+        if (action === 'create' && username !== undefined) {
+          return cf
+            .uaa
+            .getScope(username, password)
+            .then(scopes => {
+              const isAdmin = _.includes(scopes, 'cloud_controller.admin');
+              if (!isAdmin) {
+                throw new errors.Forbidden('Token has insufficient scope');
+              }
+            });
         }
       })
       .then(() => this.generateManifest(deploymentName, opts))

--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -168,6 +168,7 @@ class DirectorManager extends BaseManager {
     const previousValues = _.get(params, 'previous_values');
     const action = _.isPlainObject(previousValues) ? 'update' : 'create';
     const opts = _.omit(params, 'previous_values');
+    args = _.assign(args, _.pick(params, 'parameters'));
     logger.info(`Starting to ${action} deployment '${deploymentName}'...`);
     return Promise
       .try(() => {

--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -169,12 +169,18 @@ class DirectorManager extends BaseManager {
     const previousValues = _.get(params, 'previous_values');
     const action = _.isPlainObject(previousValues) ? 'update' : 'create';
     const opts = _.omit(params, 'previous_values');
-    args = _.assign(args, _.pick(params, 'parameters'));
+    args = _.assign(args, _.pick(params, 'parameters.bosh_director_name'));
+    const username = _.get(params, 'parameters.username');
+    const password = _.get(params, 'parameters.password');
     logger.info(`Starting to ${action} deployment '${deploymentName}'...`);
     return Promise
       .try(() => {
         switch (action) {
         case 'update':
+          if (_.get(params, 'parameters.bosh_director_name') ||
+            username || password) {
+            throw new BadRequest(`Update cannot be done on custom BOSH`);
+          }
           return this
             .getDeploymentManifest(deploymentName)
             .then(manifest => _
@@ -185,22 +191,18 @@ class DirectorManager extends BaseManager {
               })
             );
         default:
+          if (action === 'create' && username !== undefined) {
+            return cf
+              .uaa
+              .getScope(username, password)
+              .then(scopes => {
+                const isAdmin = _.includes(scopes, 'cloud_controller.admin');
+                if (!isAdmin) {
+                  throw new errors.Forbidden('Token has insufficient scope');
+                }
+              });
+          }
           return;
-        }
-      })
-      .then(() => {
-        const username = _.get(args, 'parameters.username');
-        const password = _.get(args, 'parameters.password');
-        if (action === 'create' && username !== undefined) {
-          return cf
-            .uaa
-            .getScope(username, password)
-            .then(scopes => {
-              const isAdmin = _.includes(scopes, 'cloud_controller.admin');
-              if (!isAdmin) {
-                throw new errors.Forbidden('Token has insufficient scope');
-              }
-            });
         }
       })
       .then(() => this.generateManifest(deploymentName, opts))

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "esformatter-use-strict": "^3.0.0",
     "esformatter-var-each": "^2.1.0",
     "isparta": "^4.0.0",
-    "js-beautify": "^1.6.3",
+    "js-beautify": "1.6.14",
     "jsdoc": "^3.4.0",
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.2.0",

--- a/test/acceptance/service-broker-api.instances.director.spec.js
+++ b/test/acceptance/service-broker-api.instances.director.spec.js
@@ -112,6 +112,7 @@ describe('service-broker-api', function () {
             queued: true
           });
           mocks.director.createOrUpdateDeployment(task_id);
+          mocks.uaa.getAccessToken();
           return chai.request(app)
             .put(`${base_url}/service_instances/${instance_id}`)
             .set('X-Broker-API-Version', api_version)
@@ -122,7 +123,9 @@ describe('service-broker-api', function () {
               organization_guid: organization_guid,
               space_guid: space_guid,
               parameters: {
-                bosh_director_name: 'bosh'
+                bosh_director_name: 'bosh',
+                username: 'admin',
+                password: 'admin'
               },
               accepts_incomplete: accepts_incomplete
             })
@@ -134,7 +137,9 @@ describe('service-broker-api', function () {
               expect(_.pick(decoded, ['type', 'parameters', 'space_guid'])).to.eql({
                 type: 'create',
                 parameters: {
-                  bosh_director_name: 'bosh'
+                  bosh_director_name: 'bosh',
+                  username: 'admin',
+                  password: 'admin'
                 },
                 space_guid: space_guid
               });

--- a/test/acceptance/service-broker-api.instances.director.spec.js
+++ b/test/acceptance/service-broker-api.instances.director.spec.js
@@ -107,6 +107,41 @@ describe('service-broker-api', function () {
               mocks.verify();
             });
         });
+        it('returns 202 Accepted when invoked with bosh name', function () {
+          mocks.director.getDeployments({
+            queued: true
+          });
+          mocks.director.createOrUpdateDeployment(task_id);
+          return chai.request(app)
+            .put(`${base_url}/service_instances/${instance_id}`)
+            .set('X-Broker-API-Version', api_version)
+            .auth(config.username, config.password)
+            .send({
+              service_id: service_id,
+              plan_id: plan_id,
+              organization_guid: organization_guid,
+              space_guid: space_guid,
+              parameters: {
+                bosh_director_name: 'bosh'
+              },
+              accepts_incomplete: accepts_incomplete
+            })
+            .then(res => {
+              expect(res).to.have.status(202);
+              expect(res.body.dashboard_url).to.equal(dashboard_url);
+              expect(res.body).to.have.property('operation');
+              const decoded = utils.decodeBase64(res.body.operation);
+              expect(_.pick(decoded, ['type', 'parameters', 'space_guid'])).to.eql({
+                type: 'create',
+                parameters: {
+                  bosh_director_name: 'bosh'
+                },
+                space_guid: space_guid
+              });
+              expect(decoded.task_id).to.eql(`${deployment_name}_${task_id}`);
+              mocks.verify();
+            });
+        });
       });
 
       describe('#update', function () {

--- a/test/mocks/uaa.js
+++ b/test/mocks/uaa.js
@@ -49,6 +49,7 @@ function getAccessToken() {
     .reply(200, {
       access_token: jwtToken,
       refresh_token: jwtToken,
+      scope: 'cloud_controller.admin',
       token_type: 'bearer'
     });
 }


### PR DESCRIPTION
This commit enables

* service-fabrik-broker to recognize json parameter
  passed to `cf create-service` command and deploy to the BOSH specified.

  ```
  {
   bosh_director_name: <bosh>,
   username: <user_name>,
   password: <password>
  }
  ```

  This bosh_director_name if provided is used to chose the bosh where
  the deployment is to be created.  If no director_name is provided the
  default bosh is used for create.

* With multiple BOSH updates to instances in old BOSH were failing and
a new instance was created in the currently active BOSH.
Any create/update request first checks to see the BOSH in which the
instance exist and then perform update on that BOSH.