### PR TITLE
Check for forbidden manifest changes in admin update API

### DIFF
--- a/lib/controllers/ServiceFabrikAdminController.js
+++ b/lib/controllers/ServiceFabrikAdminController.js
@@ -24,24 +24,42 @@ class ServiceFabrikAdminController extends BaseController {
   }
 
   updateDeployment(req, res) {
+    const self = this;
     const redirect_uri = _.get(req.query, 'redirect_uri', '/admin/deployments/outdated');
-    return this.fabrik
-      .createOperation('update', {
-        deployment: req.params.name,
-        username: req.user.name,
-        arguments: req.body
-      })
-      .invoke()
-      .then(body => {
-        res.format({
-          html: () => res
-            .redirect(303, redirect_uri),
-          default: () => res
-            .status(200)
-            .send(body)
-        });
+    const allowForbiddenManifestChanges = (req.body.forbidden_changes === undefined) ? true :
+      JSON.parse(req.body.forbidden_changes);
+    const deploymentName = req.params.name;
 
-      });
+    function updateDeployment() {
+      return self.fabrik
+        .createOperation('update', {
+          deployment: deploymentName,
+          username: req.user.name,
+          arguments: req.body
+        }).invoke()
+        .then(body => {
+          res.format({
+            html: () => res
+              .redirect(303, redirect_uri),
+            default: () => res
+              .status(200)
+              .send(body)
+          });
+        });
+    }
+    logger.info(`Forbidden Manifest flag set to ${allowForbiddenManifestChanges}`);
+    if (allowForbiddenManifestChanges === false) {
+      const instanceId = this.parseServiceInstanceIdFromDeployment(deploymentName);
+      return this
+        .getServicePlanIdForInstanceId(instanceId)
+        .then(planId => this.getOutdatedDiff(deploymentName, catalog.getPlan(planId)))
+        .then(diff => this.checkForbiddenManifestChanges(deploymentName, diff))
+        .tap(() => logger.info(`Doing update for ${deploymentName} as there is no forbidden changes in manifest`))
+        .then(() => updateDeployment());
+    } else {
+      logger.info(`Doing update for ${deploymentName} even if forbidden changes exist in manifest`);
+      return updateDeployment();
+    }
   }
 
   updateOutdatedDeployments(req, res) {
@@ -50,23 +68,7 @@ class ServiceFabrikAdminController extends BaseController {
     function updateDeployment(deployment) {
       return Promise
         .try(() => {
-          const forbiddenSections = _
-            .chain(deployment.diff)
-            .map(_.first)
-            .filter(line => /^[a-z]\w+:/.test(line))
-            .map(line => _.nth(/^([a-z]\w+):/.exec(line), 1))
-            .difference([
-              'update',
-              'compilation',
-              'releases',
-              'resource_pools',
-              'networks',
-              'properties'
-            ])
-            .value();
-          if (!_.isEmpty(forbiddenSections) && !_.includes(forbiddenSections, 'director_uuid')) {
-            throw new Forbidden(`Automatic update not possible. Detected changes in forbidden section(s) '${forbiddenSections.join(',')}'`);
-          }
+          self.checkForbiddenManifestChanges(deployment.name, deployment.diff);
         })
         .then(() => self.fabrik
           .createOperation('update', {
@@ -93,6 +95,55 @@ class ServiceFabrikAdminController extends BaseController {
         .status(202)
         .send(body)
       );
+  }
+
+  checkForbiddenManifestChanges(deploymentName, diff) {
+    logger.debug(`Starting check for Forbidden manifest changes in ${deploymentName}`);
+    const forbiddenSections = _
+      .chain(diff)
+      .map(_.first)
+      .filter(line => /^[a-z]\w+:/.test(line))
+      .map(line => _.nth(/^([a-z]\w+):/.exec(line), 1))
+      .difference([
+        'update',
+        'compilation',
+        'releases',
+        'resource_pools',
+        'networks',
+        'properties'
+      ])
+      .value();
+    if (!_.isEmpty(forbiddenSections) && !_.includes(forbiddenSections, 'director_uuid')) {
+      throw new Forbidden(`Automatic update not possible.` +
+        `Detected changes in forbidden section(s):` +
+        `'${forbiddenSections.join(', ')}'`);
+    }
+  }
+
+  parseServiceInstanceIdFromDeployment(deploymentName) {
+    const deploymentNameArray = utils.deploymentNameRegExp().exec(deploymentName);
+    if (deploymentNameArray !== undefined && deploymentNameArray.length === 4) {
+      return deploymentNameArray[3];
+    }
+    return deploymentName;
+  }
+
+  getServicePlanIdForInstanceId(instanceId) {
+    logger.debug(`Fetching service plan id for instance id :  ${instanceId}`);
+    return this.cloudController
+      .findServicePlanByInstanceId(instanceId)
+      .then(body => body.entity.unique_id)
+      .catch(errors.ServiceInstanceNotFound, () => undefined);
+  }
+
+  getOutdatedDiff(deploymentName, plan) {
+    logger.debug(`Getting outdated diff for  :  ${deploymentName}`);
+    return this.fabrik
+      .createManager(plan)
+      .then((directorManager) => directorManager
+        .diffManifest(deploymentName)
+        .tap(result => logger.debug(`Diff of manifest for ${deploymentName} is ${result.diff}`))
+        .then(result => result.diff));
   }
 
   getDeployments(req, res, onlySummary) {

--- a/test/acceptance/service-fabrik-admin.instances.director.spec.js
+++ b/test/acceptance/service-fabrik-admin.instances.director.spec.js
@@ -119,6 +119,30 @@ describe('service-fabrik-admin', function () {
               mocks.verify();
             });
         });
+        it('should initiate a service-fabrik-(update)operation with forbidden manifest changes disable', function () {
+          mocks.cloudController.findServicePlan(instance_id, plan_unique_id);
+          mocks.director.getDeploymentManifest();
+          mocks.director.diffDeploymentManifest();
+          mocks.cloudController.updateServiceInstance(instance_id, body => {
+            const token = _.get(body.parameters, 'service-fabrik-operation');
+            return support.jwt.verify(token, name, args);
+          });
+          return chai
+            .request(apps.internal)
+            .post(`${base_url}/deployments/${deployment_name}/update`)
+            .send({
+              forbidden_changes: 'false'
+            })
+            .set('Accept', 'application/json')
+            .auth(config.username, config.password)
+            .catch(err => err.response)
+            .then(res => {
+              expect(res).to.have.status(200);
+              expect(res.body.name).to.equal(name);
+              expect(res.body).to.have.property('guid');
+              mocks.verify();
+            });
+        });
       });
 
       describe('#updateOutdatedDeployments', function () {


### PR DESCRIPTION
The current implementation of admin update api updates instances without
any checks.

* This commit adds support for a boolean parameter `forbidden_changes` which
  can be sent along with the POST request to prevent the update if
  forbidden manifest changes are present in the deployment diff.
  `forbidden_changes` parameter defaults to true.

* Update the template string to avoid unexpected newlines

This PR is for https://github.com/SAP/service-fabrik-broker/issues/24