### PR TITLE
Update create check

### DIFF
--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -192,7 +192,7 @@ class DirectorManager extends BaseManager {
               })
             );
         default:
-          if (action === 'create' && username !== undefined) {
+          if (action === 'create' && _.get(params, 'parameters.bosh_director_name')) {
             return cf
               .uaa
               .getScope(username, password)


### PR DESCRIPTION
The existing check does not check for username undefined.
More accurate check is to check for the username scope when the
bosh_director_name is provided.