### PR TITLE
Closes issue #74: Availability set configuration for Azure landscapes

### DIFF
--- a/config/templates/blueprint-manifest.yml.ejs
+++ b/config/templates/blueprint-manifest.yml.ejs
@@ -1,4 +1,4 @@
-<%= spec.header.select({disk_pools: [p('disk_pool')], resource_pools: [p('resource_pool')]}) %>
+<%= spec.header.select({disk_pools: [p('disk_pool')], resource_pools: [{name: p('resource_pool')}]}) %>
 
 update:
   canaries: 0

--- a/config/templates/mongodb-manifest.yml.ejs
+++ b/config/templates/mongodb-manifest.yml.ejs
@@ -1,4 +1,4 @@
-<%= spec.header.select({disk_pools: [p('disk_pool')], resource_pools: [p('resource_pool')]}) %>
+<%= spec.header.select({disk_pools: [p('disk_pool')], resource_pools: [{name: p('resource_pool')}]}) %>
 
 update:
   canaries: 1

--- a/lib/bosh/manifest/Header.js
+++ b/lib/bosh/manifest/Header.js
@@ -56,7 +56,9 @@ class Header {
           });
           if (matched_attribute.length > 0) {
             let cloud_properties = matched_attribute[0].cloud_properties;
-            _.assign(resource_pool.cloud_properties, cloud_properties[config.backup.provider.name]);
+            if (cloud_properties) {
+              _.assign(resource_pool.cloud_properties, cloud_properties[config.backup.provider.name]);
+            }
           }
 
           return _.includes(resource_pool_names, match[1]);

--- a/lib/bosh/manifest/Header.js
+++ b/lib/bosh/manifest/Header.js
@@ -3,6 +3,7 @@
 
 const yaml = require('js-yaml');
 const _ = require('lodash');
+const config = require('../../config');
 
 class Header {
   constructor(header) {
@@ -17,14 +18,14 @@ class Header {
 
   select(options) {
     let disk_pool_names = options.disk_pools || [];
-    let resource_pool_names = options.resource_pools || [];
+    let resource_pools_to_include = options.resource_pools || [];
     return new Header({
       name: this.name,
       director_uuid: this.director_uuid,
       releases: this.releases,
       compilation: this.compilation,
       disk_pools: this.constructor.filterDiskPools(this.disk_pools, disk_pool_names),
-      resource_pools: this.constructor.filterResourcePools(this.resource_pools, resource_pool_names),
+      resource_pools: this.constructor.filterResourcePools(this.resource_pools, resource_pools_to_include),
       networks: this.networks
     });
   }
@@ -44,11 +45,20 @@ class Header {
     return disk_pools;
   }
 
-  static filterResourcePools(resource_pools, resource_pool_names) {
+  static filterResourcePools(resource_pools, resource_pools_to_include) {
+    const resource_pool_names = _.map(resource_pools_to_include, 'name');
     if (resource_pool_names && resource_pool_names.length) {
       return resource_pools.filter((resource_pool) => {
         let match = /^(.*)_[a-zA-Z0-9]+$/.exec(resource_pool.name);
         if (match) {
+          let matched_attribute = _.filter(resource_pools_to_include, {
+            'name': match[1]
+          });
+          if (matched_attribute.length > 0) {
+            let cloud_properties = matched_attribute[0].cloud_properties;
+            _.assign(resource_pool.cloud_properties, cloud_properties[config.backup.provider.name]);
+          }
+
           return _.includes(resource_pool_names, match[1]);
         }
         return false;

--- a/test/bosh.manifest.Header.spec.js
+++ b/test/bosh.manifest.Header.spec.js
@@ -70,7 +70,6 @@ describe('bosh', () => {
       describe('#filterDiskPools', () => {
         it('returns an array containing one element', () => {
           let disk_pools = Header.filterDiskPools(header.disk_pools, ['bar']);
-
           expect(disk_pools).to.be.a('Array');
           expect(disk_pools).to.have.length(1);
         });
@@ -78,10 +77,23 @@ describe('bosh', () => {
 
       describe('#filterResourcePools', () => {
         it('returns an array containing one element', () => {
-          let disk_pools = Header.filterResourcePools(header.resource_pools, ['barfoo', 'foobar']);
-
-          expect(disk_pools).to.be.a('Array');
-          expect(disk_pools).to.have.length(1);
+          let resource_pools = Header.filterResourcePools(header.resource_pools, [{
+            name: 'foobar',
+            cloud_properties: {
+              azure: {
+                availability_set: 'bar'
+              }
+            }
+          }, {
+            name: 'barfoo',
+            cloud_properties: {
+              azure: {
+                availability_set: 'bar'
+              }
+            }
+          }]);
+          expect(resource_pools).to.be.a('Array');
+          expect(resource_pools).to.have.length(1);
         });
       });
     });


### PR DESCRIPTION
Description: 
1. Modified the resource pools filtering to handle the new inputs of availability set from the manifest, 
2. Made this part iaas specific and driven from config, 
3. Added/modified UTs

Fixes #74 