### PR TITLE
Tag Resources with Org Id, Space Id

### DIFF
--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const yaml = require('js-yaml');
 const Promise = require('bluebird');
 const config = require('../config');
 const logger = require('../logger');
@@ -339,7 +340,18 @@ class DirectorManager extends BaseManager {
         previous_manifest: manifest
       }));
   }
-
+  addVmtags(template_manifest, opts) {
+    const tagInfo = {
+      organization_guid: opts.organization_guid ? opts.organization_guid : null,
+      space_guid: opts.space_guid ? opts.space_guid : null
+    };
+    const vm_tags = {
+      tags: tagInfo
+    };
+    var manifest_object = yaml.safeLoad(template_manifest);
+    _.assign(manifest_object, vm_tags);
+    return yaml.safeDump(manifest_object);
+  }
   generateManifest(deploymentName, opts) {
     const index = opts.network_index || this.getNetworkSegmentIndex(deploymentName);
     const networks = this.getNetworks(index);
@@ -369,7 +381,8 @@ class DirectorManager extends BaseManager {
       logger.error(`subnet ${this.networkName} definition not found among the applicable networks defintion : ${JSON.stringify(networks)}`);
       throw new errors.UnprocessableEntity(`subnet ${this.networkName} definition not found`);
     }
-    return _.template(this.template)(context);
+    var template_manifest = _.template(this.template)(context);
+    return this.addVmtags(template_manifest, opts);
   }
 
   findDeploymentTask(deploymentName) {

--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -348,6 +348,7 @@ class DirectorManager extends BaseManager {
     const vm_tags = {
       tags: tagInfo
     };
+    logger.info(`Adding VM tags in manifest: `, vm_tags);
     var manifest_object = yaml.safeLoad(template_manifest);
     _.assign(manifest_object, vm_tags);
     return yaml.safeDump(manifest_object);

--- a/test/fabrik.DirectorManager.spec.js
+++ b/test/fabrik.DirectorManager.spec.js
@@ -55,6 +55,22 @@ describe('fabrik', function () {
         manager.findNetworkSegmentIndex(used_guid).then(res => expect(res).to.eql(21));
       });
     });
+    describe('#addVmtags', function () {
+      it('should append organization guid and space guid to manifest', function () {
+        //Test case #1 {When opts has org and space keys}
+        var test_manifest = 'properties:\n  a: 1\n  b: 2';
+        var opts = {
+          organization_guid: 'myorg',
+          space_guid: 'myspace'
+        };
+        var expected_manifest = 'properties:\n  a: 1\n  b: 2\ntags:\n  organization_guid: myorg\n  space_guid: myspace\n';
+        expect(manager.addVmtags(test_manifest, opts)).to.eql(expected_manifest);
+        //Test case #2 {When opts does not have org and space key}
+        opts = {};
+        expected_manifest = 'properties:\n  a: 1\n  b: 2\ntags:\n  organization_guid: null\n  space_guid: null\n';
+        expect(manager.addVmtags(test_manifest, opts)).to.eql(expected_manifest);
+      });
+    });
 
   });
 });


### PR DESCRIPTION
Tagging happens only for new deployments.
* Added tags block in deployment manifest
* Added Unit test
tags:
  organization_guid: 
  space_guid: