### PR TITLE
Initializing initialJobRunStatus to first jobrun status

### DIFF
--- a/lib/jobs/ServiceInstanceUpdateJob.js
+++ b/lib/jobs/ServiceInstanceUpdateJob.js
@@ -204,14 +204,14 @@ class ServiceInstanceUpdateJob extends BaseJob {
         }
         const lastRunList = lastRunDetails.list;
         const count = lastRunList.length;
-        let initialJobRunStatus, idx;
-        for (idx = 0; idx < count; idx++) {
+        let initialJobRunStatus = lastRunList[count - 1];
+        for (let idx = 0; idx < count; idx++) {
           if (lastRunList[idx].data.attempt === 1) {
             initialJobRunStatus = lastRunList[idx];
             break;
           }
         }
-        logger.debug('Initial run status - ', initialJobRunStatus);
+        logger.info('Initial run status - ', initialJobRunStatus);
         const diffBeforeUpdate = _.get(initialJobRunStatus, 'response.diff', null) || _.get(initialJobRunStatus, 'response.jobStatus.diff', null);
         const diffAfterUpdate = count === 1 ? 'TBD' : (_.get(lastRunList[0], 'response.diff') ||
           _.get(lastRunList[0], 'response.jobStatus.diff', null));


### PR DESCRIPTION
When backups are running in background the number of retry attempts are not restricted to 3. However when lastrunstatus is checked only last 3 records from job history are fetched & the initial job run status was picked up based on the attempt count. In case of backup runs, we initial job run might not be present in the last 3 run records & hence this scenario could lead to an error while fetching the last run status.
The fix to this issue is to initialise the initialJobRunStatus to the last entry from the fetched set of records. By doing so, we ensure this is always defined.