### PR TITLE
Revert "Merge pull request #80 from amitmalav/feature/vmtags"

### DIFF
--- a/lib/fabrik/DirectorManager.js
+++ b/lib/fabrik/DirectorManager.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const yaml = require('js-yaml');
 const Promise = require('bluebird');
 const config = require('../config');
 const logger = require('../logger');
@@ -340,19 +339,7 @@ class DirectorManager extends BaseManager {
         previous_manifest: manifest
       }));
   }
-  addVmtags(template_manifest, opts) {
-    const tagInfo = {
-      organization_guid: opts.organization_guid ? opts.organization_guid : null,
-      space_guid: opts.space_guid ? opts.space_guid : null
-    };
-    const vm_tags = {
-      tags: tagInfo
-    };
-    logger.info(`Adding VM tags in manifest: `, vm_tags);
-    var manifest_object = yaml.safeLoad(template_manifest);
-    _.assign(manifest_object, vm_tags);
-    return yaml.safeDump(manifest_object);
-  }
+
   generateManifest(deploymentName, opts) {
     const index = opts.network_index || this.getNetworkSegmentIndex(deploymentName);
     const networks = this.getNetworks(index);
@@ -382,8 +369,7 @@ class DirectorManager extends BaseManager {
       logger.error(`subnet ${this.networkName} definition not found among the applicable networks defintion : ${JSON.stringify(networks)}`);
       throw new errors.UnprocessableEntity(`subnet ${this.networkName} definition not found`);
     }
-    var template_manifest = _.template(this.template)(context);
-    return this.addVmtags(template_manifest, opts);
+    return _.template(this.template)(context);
   }
 
   findDeploymentTask(deploymentName) {

--- a/test/fabrik.DirectorManager.spec.js
+++ b/test/fabrik.DirectorManager.spec.js
@@ -55,22 +55,6 @@ describe('fabrik', function () {
         manager.findNetworkSegmentIndex(used_guid).then(res => expect(res).to.eql(21));
       });
     });
-    describe('#addVmtags', function () {
-      it('should append organization guid and space guid to manifest', function () {
-        //Test case #1 {When opts has org and space keys}
-        var test_manifest = 'properties:\n  a: 1\n  b: 2';
-        var opts = {
-          organization_guid: 'myorg',
-          space_guid: 'myspace'
-        };
-        var expected_manifest = 'properties:\n  a: 1\n  b: 2\ntags:\n  organization_guid: myorg\n  space_guid: myspace\n';
-        expect(manager.addVmtags(test_manifest, opts)).to.eql(expected_manifest);
-        //Test case #2 {When opts does not have org and space key}
-        opts = {};
-        expected_manifest = 'properties:\n  a: 1\n  b: 2\ntags:\n  organization_guid: null\n  space_guid: null\n';
-        expect(manager.addVmtags(test_manifest, opts)).to.eql(expected_manifest);
-      });
-    });
 
   });
 });


### PR DESCRIPTION
This reverts commit f74f52f0f07beb9e74fbb6264fbc91c42c3f7861, reversing
changes made to b47c78bf28078f1cb3e84e25cdfda8c0f5d92c8b.

Code has been reverted since tags is currently not supported by BOSH v1.0 manifest and this breaks the BOSH manifest diff API.