### PR TITLE
Configured reschedule delay and max_attempt at job level

### DIFF
--- a/lib/controllers/ServiceFabrikApiController.js
+++ b/lib/controllers/ServiceFabrikApiController.js
@@ -490,12 +490,15 @@ class ServiceFabrikApiController extends BaseController {
           .then(instance => _.set(req, 'entity.name', instance.entity.name));
       })
       .then(() => req.manager.findDeploymentNameByInstanceId(req.params.instance_id))
-      .then(deploymentName => ({
-        instance_id: req.params.instance_id,
-        instance_name: req.entity.name,
-        deployment_name: deploymentName,
-        timeZone: req.body.timeZone
-      }))
+      .then(deploymentName => _
+        .chain({
+          instance_id: req.params.instance_id,
+          instance_name: req.entity.name,
+          deployment_name: deploymentName
+        })
+        .assign(req.body)
+        .value()
+      )
       .then((jobData) => ScheduleManager
         .schedule(req.params.instance_id,
           CONST.JOB.SERVICE_INSTANCE_UPDATE,

--- a/lib/controllers/ServiceFabrikApiController.js
+++ b/lib/controllers/ServiceFabrikApiController.js
@@ -496,7 +496,7 @@ class ServiceFabrikApiController extends BaseController {
           instance_name: req.entity.name,
           deployment_name: deploymentName
         })
-        .assign(req.body)
+        .assign(_.omit(req.body, 'repeatInterval'))
         .value()
       )
       .then((jobData) => ScheduleManager

--- a/lib/jobs/ScheduleBackupJob.js
+++ b/lib/jobs/ScheduleBackupJob.js
@@ -139,15 +139,17 @@ class ScheduleBackupJob extends BaseJob {
     return Promise.try(() => {
       const jobData = _.cloneDeep(jobOptions);
       jobData.attempt = jobData.attempt + 1;
-      if (jobData.attempt > _.get(jobData, 'max_attempts', config.scheduler.jobs.scheduled_backup.max_attempts)) {
-        logger.error(`Scheduled backup for instance  ${jobData.instance_id} has exceeded max configured attempts : ${config.scheduler.jobs.scheduled_backup.max_attempts} - ${jobData.attempt}}. Initial attempt was done @: ${jobData.firstAttemptAt}.`);
+      const MAX_ATTEMPTS = _.get(jobData, 'max_attempts', config.scheduler.jobs.scheduled_backup.max_attempts);
+      if (jobData.attempt > MAX_ATTEMPTS) {
+        logger.error(`Scheduled backup for instance  ${jobData.instance_id} has exceeded max configured attempts : ${MAX_ATTEMPTS} - ${jobData.attempt}}. Initial attempt was done @: ${jobData.firstAttemptAt}.`);
         throw new errors.toManyAttempts(config.scheduler.jobs.scheduled_backup.max_attempts, new Error(`Failed to reschedule backup for ${jobData.instance_id}`));
       }
-      logger.info(`Re-Schedulding Backup Job for ${jobData.instance_id} @ ${config.scheduler.jobs.reschedule_delay} - Attempt - ${jobData.attempt}. Initial attempt was done @: ${jobData.firstAttemptAt}`);
+      const RUN_AFTER = _.get(jobData, 'reschedule_delay', config.scheduler.jobs.reschedule_delay);
+      logger.info(`Re-Schedulding Backup Job for ${jobData.instance_id} @ ${RUN_AFTER} - Attempt - ${jobData.attempt}. Initial attempt was done @: ${jobData.firstAttemptAt}`);
       return ScheduleManager
         .runAt(jobData.instance_id,
           CONST.JOB.SCHEDULED_BACKUP,
-          _.get(jobData, 'reschedule_delay', config.scheduler.jobs.reschedule_delay),
+          RUN_AFTER,
           jobData,
           CONST.SYSTEM_USER
         );

--- a/lib/jobs/ScheduleBackupJob.js
+++ b/lib/jobs/ScheduleBackupJob.js
@@ -139,7 +139,7 @@ class ScheduleBackupJob extends BaseJob {
     return Promise.try(() => {
       const jobData = _.cloneDeep(jobOptions);
       jobData.attempt = jobData.attempt + 1;
-      if (jobData.attempt > config.scheduler.jobs.scheduled_backup.max_attempts) {
+      if (jobData.attempt > _.get(jobData, 'max_attempts', config.scheduler.jobs.scheduled_backup.max_attempts)) {
         logger.error(`Scheduled backup for instance  ${jobData.instance_id} has exceeded max configured attempts : ${config.scheduler.jobs.scheduled_backup.max_attempts} - ${jobData.attempt}}. Initial attempt was done @: ${jobData.firstAttemptAt}.`);
         throw new errors.toManyAttempts(config.scheduler.jobs.scheduled_backup.max_attempts, new Error(`Failed to reschedule backup for ${jobData.instance_id}`));
       }
@@ -147,7 +147,7 @@ class ScheduleBackupJob extends BaseJob {
       return ScheduleManager
         .runAt(jobData.instance_id,
           CONST.JOB.SCHEDULED_BACKUP,
-          config.scheduler.jobs.reschedule_delay,
+          _.get(jobData, 'reschedule_delay', config.scheduler.jobs.reschedule_delay),
           jobData,
           CONST.SYSTEM_USER
         );

--- a/lib/jobs/ServiceInstanceUpdateJob.js
+++ b/lib/jobs/ServiceInstanceUpdateJob.js
@@ -150,7 +150,7 @@ class ServiceInstanceUpdateJob extends BaseJob {
       const jobData = _.cloneDeep(instanceDetails);
       jobData.attempt = jobData.attempt + 1;
       if (trackAttempts) {
-        if (jobData.attempt > config.scheduler.jobs.service_instance_update.max_attempts) {
+        if (jobData.attempt > _.get(instanceDetails, 'max_attempts', config.scheduler.jobs.service_instance_update.max_attempts)) {
           logger.error(`Auto udpate for instance ${instanceDetails.instance_id}  has exceeded max configured attempts : ${config.scheduler.jobs.service_instance_update.max_attempts}}`);
           return;
         }
@@ -159,7 +159,7 @@ class ServiceInstanceUpdateJob extends BaseJob {
       return ScheduleManager
         .runAt(instanceDetails.instance_id,
           CONST.JOB.SERVICE_INSTANCE_UPDATE,
-          config.scheduler.jobs.reschedule_delay,
+          _.get(instanceDetails, 'reschedule_delay', config.scheduler.jobs.reschedule_delay),
           jobData,
           CONST.SYSTEM_USER
         );

--- a/lib/jobs/ServiceInstanceUpdateJob.js
+++ b/lib/jobs/ServiceInstanceUpdateJob.js
@@ -150,16 +150,18 @@ class ServiceInstanceUpdateJob extends BaseJob {
       const jobData = _.cloneDeep(instanceDetails);
       jobData.attempt = jobData.attempt + 1;
       if (trackAttempts) {
-        if (jobData.attempt > _.get(instanceDetails, 'max_attempts', config.scheduler.jobs.service_instance_update.max_attempts)) {
-          logger.error(`Auto udpate for instance ${instanceDetails.instance_id}  has exceeded max configured attempts : ${config.scheduler.jobs.service_instance_update.max_attempts}}`);
+        const MAX_ATTEMPTS = _.get(instanceDetails, 'max_attempts', config.scheduler.jobs.service_instance_update.max_attempts);
+        if (jobData.attempt > MAX_ATTEMPTS) {
+          logger.error(`Auto udpate for instance ${instanceDetails.instance_id}  has exceeded max configured attempts : ${MAX_ATTEMPTS}}`);
           return;
         }
       }
-      logger.info(`Schedulding InstanceUpdate Job for ${instanceDetails.instance_name}:${instanceDetails.instance_id} @ ${config.scheduler.jobs.reschedule_delay} - Track : ${trackAttempts} - Attempt - ${instanceDetails.attempt}`);
+      const RUN_AFTER = _.get(instanceDetails, 'reschedule_delay', config.scheduler.jobs.reschedule_delay);
+      logger.info(`Schedulding InstanceUpdate Job for ${instanceDetails.instance_name}:${instanceDetails.instance_id} @ ${RUN_AFTER} - Track : ${trackAttempts} - Attempt - ${instanceDetails.attempt}`);
       return ScheduleManager
         .runAt(instanceDetails.instance_id,
           CONST.JOB.SERVICE_INSTANCE_UPDATE,
-          _.get(instanceDetails, 'reschedule_delay', config.scheduler.jobs.reschedule_delay),
+          RUN_AFTER,
           jobData,
           CONST.SYSTEM_USER
         );


### PR DESCRIPTION
Currently if an updaate job fails because of  a backup job running or
vice versa, the failed job is rescheduled after a configured
reschedule_delay which is at app level. While this works perfectly,
this will make testing these in an automated way difficult as the
validation must wait to longer periods since the default value
of this attrib is 20 minutes. Hence to overcome this, this param
along with max_attempts can be configured at job level when the
job is scheduled (both backup/update). Please note these overrides
are to be done only for purposes of testing and should not be
(mis)used for any other scenarios.