### PR TITLE
db update failures must return back create_update_failed as status

### DIFF
--- a/lib/fabrik/DBManager.js
+++ b/lib/fabrik/DBManager.js
@@ -255,7 +255,7 @@ class DBManager {
   }
 
   getState() {
-    if (this.dbState !== DB_STATES.CREATE_UPDATE_IN_PROGRESS) {
+    if (this.dbState !== DB_STATES.CREATE_UPDATE_IN_PROGRESS && this.dbState !== DB_STATES.CREATE_UPDATE_FAILED) {
       //If update is in progress, do not check status from connection manager. Create/Update status has highest precedence
       if (dbConnectionManager.getConnectionStatus() === CONST.DB.CONNECTION_STATE.CONNECTED) {
         this.dbState = DB_STATES.CONNECTED;


### PR DESCRIPTION
When DB update failures occurs, even though DB deployment update would have failed DB could be still reachable and currently a status of CONNECTED is being returned back. Even though this does reflect the state that app is able to connect to DB, it does not reflect the state that DB update has failed. Not flagging this would mean that SF deployment would be getting marked as GREEN. So its important to flag the status as DB_UPDATE_FAILED so that SF deployment job fails and someone can take action on it immediately