### PR TITLE
Add support to skip logging requests with client errors to riemann

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -203,6 +203,8 @@ defaults: &defaults
     protocol : tcp
     show_errors: false
     prefix: CF
+    log_additional_event: true
+    skip_http_status_40x: true
   ###################
   # QUOTA MANAGEMENT SETTINGS #
   ###################

--- a/lib/utils/EventLogRiemannClient.js
+++ b/lib/utils/EventLogRiemannClient.js
@@ -52,7 +52,7 @@ class EventLogRiemannClient {
 
   handleEvent(message, data) {
     try {
-      if (data.event && _.get(data, 'event.response.status') !== CONST.HTTP_STATUS_CODE.BAD_REQUEST) {
+      if (data.event && !(_.get(config, 'riemann.skip_events_with_client_errors', true) && this.isEventWithClientError(_.get(data, 'event.response.status')))) {
         this.logEvent(data.event, data.options);
         //Added to log additional event with instance id or backup guid suffix to the name to provide more details to email alerts
         if (_.get(config, 'riemann.log_additional_event', true) && typeof data.event.request === 'object' && this.suffixGuidsToEventName(data.event)) {
@@ -90,6 +90,10 @@ class EventLogRiemannClient {
     }
     eventInfo.eventName = eventName;
     return true;
+  }
+
+  isEventWithClientError(httpResponseCode) {
+    return (new RegExp(`^4..$`)).test(httpResponseCode);
   }
 
   disconnect() {

--- a/lib/utils/EventLogRiemannClient.js
+++ b/lib/utils/EventLogRiemannClient.js
@@ -52,7 +52,7 @@ class EventLogRiemannClient {
 
   handleEvent(message, data) {
     try {
-      if (data.event && !(_.get(config, 'riemann.skip_events_with_client_errors', true) && this.isEventWithClientError(_.get(data, 'event.response.status')))) {
+      if (data.event && !(_.get(config, 'riemann.skip_http_status_40x', true) && this.isEventWithClientError(_.get(data, 'event.response.status')))) {
         this.logEvent(data.event, data.options);
         //Added to log additional event with instance id or backup guid suffix to the name to provide more details to email alerts
         if (_.get(config, 'riemann.log_additional_event', true) && typeof data.event.request === 'object' && this.suffixGuidsToEventName(data.event)) {


### PR DESCRIPTION
Added support in broker which would skip sending events to riemann if the incoming requests to broker failed because of client error .

https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_errors.