### PR TITLE
cache issue - deployment found in more than one director

### DIFF
--- a/lib/bosh/BoshDirectorClient.js
+++ b/lib/bosh/BoshDirectorClient.js
@@ -170,10 +170,7 @@ class BoshDirectorClient extends HttpClient {
     return this.getDirectorConfig(deploymentName)
       .then(directorConfig => this.makeRequestWithConfig(requestDetails, expectedStatusCode, directorConfig))
       .catch(NotFound, (err) => {
-        try {
-          const errResponse = JSON.parse(err.error);
-          err.error = errResponse;
-        } catch (err) {}
+        logger.warn(`${deploymentName} not found. Attempt - ${attempt} -  error details`, err.error);
         if (attempt === undefined && _.get(err, 'error.code') === CONST.BOSH_ERR_CODES.DEPLOYMENT_NOT_FOUND) {
           logger.debug('Going to delete the entry from cache for the deployment:', deploymentName);
           this.deleteCacheEntry(deploymentName);
@@ -205,6 +202,7 @@ class BoshDirectorClient extends HttpClient {
   /* Deployment operations */
 
   getDeploymentsByConfig(config) {
+    this.clearCache(config);
     return this
       .makeRequestWithConfig({
         method: 'GET',

--- a/lib/bosh/BoshDirectorClient.js
+++ b/lib/bosh/BoshDirectorClient.js
@@ -172,7 +172,7 @@ class BoshDirectorClient extends HttpClient {
       .catch(NotFound, (err) => {
         logger.warn(`${deploymentName} not found. Attempt - ${attempt} -  error details`, err.error);
         if (attempt === undefined && _.get(err, 'error.code') === CONST.BOSH_ERR_CODES.DEPLOYMENT_NOT_FOUND) {
-          logger.debug('Going to delete the entry from cache for the deployment:', deploymentName);
+          logger.info('Going to delete the entry from cache for the deployment:', deploymentName);
           this.deleteCacheEntry(deploymentName);
           return this.makeRequest(requestDetails, expectedStatusCode, deploymentName, 1);
         }

--- a/lib/utils/HttpClient.js
+++ b/lib/utils/HttpClient.js
@@ -166,7 +166,15 @@ class HttpClient {
         }
         if (body && typeof body === 'object') {
           err.error = body;
+        }else if(typeof body === 'string'){
+          try {
+            const errResponse = JSON.parse(body);
+            err.error = errResponse;
+          } catch (err) {
+            logger.info('Error occurred while parsing http response- ', err.error);
+          }
         }
+        logger.warn(`Error occurred with http:`, err);
         throw err;
       }
       return result;

--- a/lib/utils/HttpClient.js
+++ b/lib/utils/HttpClient.js
@@ -166,7 +166,7 @@ class HttpClient {
         }
         if (body && typeof body === 'object') {
           err.error = body;
-        }else if(typeof body === 'string'){
+        } else if (typeof body === 'string') {
           try {
             const errResponse = JSON.parse(body);
             err.error = errResponse;

--- a/test/acceptance/service-fabrik-admin.internal-db.lifecycle.spec.js
+++ b/test/acceptance/service-fabrik-admin.internal-db.lifecycle.spec.js
@@ -65,7 +65,7 @@ describe('service-fabrik-admin', function () {
         const WAIT_TIME_FOR_ASYNCH_CREATE_DEPLOYMENT_OPERATION = 30;
         this.timeout(2000 + WAIT_TIME_FOR_ASYNCH_CREATE_DEPLOYMENT_OPERATION);
         mocks.director.getBindingProperty(CONST.FABRIK_INTERNAL_MONGO_DB.BINDING_ID, {}, config.mongodb.deployment_name, 'NOTFOUND');
-        mocks.director.getDeployment(config.mongodb.deployment_name, false);
+        mocks.director.getDeployment(config.mongodb.deployment_name, false, undefined, 2);
         mocks.director.createOrUpdateDeployment('777');
         mocks.director.getDeploymentTask('777', 'done');
         mocks.director.getDeployment(config.mongodb.deployment_name, true);

--- a/test/jobs.ScheduledOobDeploymentBackupJob.spec.js
+++ b/test/jobs.ScheduledOobDeploymentBackupJob.spec.js
@@ -193,7 +193,7 @@ describe('Jobs', function () {
       });
 
       it('should delete scheduled backup even when deployment is deleted', function (done) {
-        mocks.director.getDeployment(deploymentName, false, undefined,2);
+        mocks.director.getDeployment(deploymentName, false, undefined, 2);
         mocks.cloudProvider.list(container, prefix, [
           fileName14Daysprior
         ]);

--- a/test/jobs.ScheduledOobDeploymentBackupJob.spec.js
+++ b/test/jobs.ScheduledOobDeploymentBackupJob.spec.js
@@ -193,7 +193,7 @@ describe('Jobs', function () {
       });
 
       it('should delete scheduled backup even when deployment is deleted', function (done) {
-        mocks.director.getDeployment(deploymentName, false);
+        mocks.director.getDeployment(deploymentName, false, undefined,2);
         mocks.cloudProvider.list(container, prefix, [
           fileName14Daysprior
         ]);
@@ -227,7 +227,7 @@ describe('Jobs', function () {
       });
 
       it('should cancel backup job (itself) when there are no more backups to delete & deployment is deleted', function (done) {
-        mocks.director.getDeployment(deploymentName, false);
+        mocks.director.getDeployment(deploymentName, false, undefined, 2);
         mocks.cloudProvider.list(container, prefix, []);
         mocks.cloudProvider.list(container, prefix, []);
         return ScheduledOobDeploymentBackupJob.run(job, () => {
@@ -310,7 +310,7 @@ describe('Jobs', function () {
       });
 
       it('should delete scheduled backup even when deployment is deleted (bootstrap bosh deployments)', function (done) {
-        mocks.director.getDeployment(deploymentName, false);
+        mocks.director.getDeployment(deploymentName, false, undefined, 2);
         mocks.cloudProvider.list(container, prefix, [
           fileName14Daysprior
         ]);


### PR DESCRIPTION
getDeployments call internally reloads the cache.
In case of getDeployments call, deployments are fetched from
both bosh & bosh-sf. Now if there are some migrations happening
during this time, a deployment will move over to bosh-sf from bosh
and since the calls to get deployment are asynch, response from
bosh-sf could come before bosh and it could lead to a state where
cache might think that the same deployment exists in both directors.

Fix for this issue is, before firing getDeployments for a particular
director clear the cache contents for that director. This eliminates
the dupe issue all together.